### PR TITLE
CI build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - BREAKING CHANGE: Changed maven artifactId to "client"
+  [#9](https://github.com/tzaeschke/phtree-cpp/pull/9)
+
+### Fixed
+- CI failures on JDK 8. [#10](https://github.com/tzaeschke/phtree-cpp/pull/10)
 
 ## [0.1.0-ALPHA] - 2024-02-01
 

--- a/TODO.md
+++ b/TODO.md
@@ -72,9 +72,6 @@
 ## Plan
 
 ### 0.1.0
-- Fix CI failure (it works locally and used to work up until the release)
-- Fix 2023->2024 in headers
-- rename artifact from "scion-java-client" to "client"
 - SCMP error handling (only error, not info)
   - implement callbacks (+ option to NOT ignore)
   - E.g. MTU exceeded, path expired, checksum problem, "destination unreachable"

--- a/src/main/java/org/scion/ScionService.java
+++ b/src/main/java/org/scion/ScionService.java
@@ -162,7 +162,7 @@ public class ScionService {
       String daemonPort =
           ScionUtil.getPropertyOrEnv(PROPERTY_DAEMON_PORT, ENV_DAEMON_PORT, DEFAULT_DAEMON_PORT);
       try {
-        System.out.println("defaultService()-5 " + daemonHost + " "  + daemonPort); // TODO
+        System.out.println("defaultService()-5 " + daemonHost + " " + daemonPort); // TODO
         DEFAULT = new ScionService(daemonHost + ":" + daemonPort, Mode.DAEMON);
         return DEFAULT;
       } catch (ScionRuntimeException e) {

--- a/src/main/java/org/scion/ScionService.java
+++ b/src/main/java/org/scion/ScionService.java
@@ -129,18 +129,21 @@ public class ScionService {
       // This is not 100% thread safe, but the worst that can happen is that
       // we call close() on a Service that has already been closed.
       if (DEFAULT != null) {
+        System.out.println("defaultService()-1"); // TODO
         return DEFAULT;
       }
       // try bootstrap service IP
       String fileName =
           ScionUtil.getPropertyOrEnv(PROPERTY_BOOTSTRAP_TOPO_FILE, ENV_BOOTSTRAP_TOPO_FILE);
       if (fileName != null) {
+        System.out.println("defaultService()-2 " + fileName); // TODO
         DEFAULT = new ScionService(fileName, Mode.BOOTSTRAP_TOPO_FILE);
         return DEFAULT;
       }
 
       String server = ScionUtil.getPropertyOrEnv(PROPERTY_BOOTSTRAP_HOST, ENV_BOOTSTRAP_HOST);
       if (server != null) {
+        System.out.println("defaultService()-3 " + server); // TODO
         DEFAULT = new ScionService(server, Mode.BOOTSTRAP_SERVER_IP);
         return DEFAULT;
       }
@@ -148,6 +151,7 @@ public class ScionService {
       String naptrName =
           ScionUtil.getPropertyOrEnv(PROPERTY_BOOTSTRAP_NAPTR_NAME, ENV_BOOTSTRAP_NAPTR_NAME);
       if (naptrName != null) {
+        System.out.println("defaultService()-4 " + naptrName); // TODO
         DEFAULT = new ScionService(naptrName, Mode.BOOTSTRAP_VIA_DNS);
         return DEFAULT;
       }
@@ -158,6 +162,7 @@ public class ScionService {
       String daemonPort =
           ScionUtil.getPropertyOrEnv(PROPERTY_DAEMON_PORT, ENV_DAEMON_PORT, DEFAULT_DAEMON_PORT);
       try {
+        System.out.println("defaultService()-5 " + daemonHost + " "  + daemonPort); // TODO
         DEFAULT = new ScionService(daemonHost + ":" + daemonPort, Mode.DAEMON);
         return DEFAULT;
       } catch (ScionRuntimeException e) {

--- a/src/main/java/org/scion/ScionService.java
+++ b/src/main/java/org/scion/ScionService.java
@@ -129,21 +129,18 @@ public class ScionService {
       // This is not 100% thread safe, but the worst that can happen is that
       // we call close() on a Service that has already been closed.
       if (DEFAULT != null) {
-        System.out.println("defaultService()-1"); // TODO
         return DEFAULT;
       }
       // try bootstrap service IP
       String fileName =
           ScionUtil.getPropertyOrEnv(PROPERTY_BOOTSTRAP_TOPO_FILE, ENV_BOOTSTRAP_TOPO_FILE);
       if (fileName != null) {
-        System.out.println("defaultService()-2 " + fileName); // TODO
         DEFAULT = new ScionService(fileName, Mode.BOOTSTRAP_TOPO_FILE);
         return DEFAULT;
       }
 
       String server = ScionUtil.getPropertyOrEnv(PROPERTY_BOOTSTRAP_HOST, ENV_BOOTSTRAP_HOST);
       if (server != null) {
-        System.out.println("defaultService()-3 " + server); // TODO
         DEFAULT = new ScionService(server, Mode.BOOTSTRAP_SERVER_IP);
         return DEFAULT;
       }
@@ -151,7 +148,6 @@ public class ScionService {
       String naptrName =
           ScionUtil.getPropertyOrEnv(PROPERTY_BOOTSTRAP_NAPTR_NAME, ENV_BOOTSTRAP_NAPTR_NAME);
       if (naptrName != null) {
-        System.out.println("defaultService()-4 " + naptrName); // TODO
         DEFAULT = new ScionService(naptrName, Mode.BOOTSTRAP_VIA_DNS);
         return DEFAULT;
       }
@@ -162,7 +158,6 @@ public class ScionService {
       String daemonPort =
           ScionUtil.getPropertyOrEnv(PROPERTY_DAEMON_PORT, ENV_DAEMON_PORT, DEFAULT_DAEMON_PORT);
       try {
-        System.out.println("defaultService()-5 " + daemonHost + " " + daemonPort); // TODO
         DEFAULT = new ScionService(daemonHost + ":" + daemonPort, Mode.DAEMON);
         return DEFAULT;
       } catch (ScionRuntimeException e) {

--- a/src/test/java/org/scion/demo/DemoConstants.java
+++ b/src/test/java/org/scion/demo/DemoConstants.java
@@ -20,6 +20,7 @@ public class DemoConstants {
 
   public enum Network {
     MOCK_TOPOLOGY, // SCION Java JUnit mock network
+    MOCK_TOPOLOGY_IPV4, // SCION Java JUnit mock network, IPv4 only
     TINY_PROTO, // Try to connect to "tiny" scionproto network
     MINIMAL_PROTO, // Try to connect to "minimal" scionproto network
     PRODUCTION // production network

--- a/src/test/java/org/scion/demo/DemoTopology.java
+++ b/src/test/java/org/scion/demo/DemoTopology.java
@@ -40,12 +40,16 @@ class DemoTopology {
     return cfg;
   }
 
-  static DemoTopology configureMock() {
+  static DemoTopology configureMock(boolean remoteIPv4) {
     DemoTopology cfg = new DemoTopology();
-    MockNetwork.startTiny(true, false);
+    MockNetwork.startTiny(true, remoteIPv4);
     cfg.clientDaemonAddress = MockDaemon.DEFAULT_ADDRESS;
     //    cfg.serverDaemonAddress = new InetSocketAddress("fd00:f00d:cafe::7", 30255);
     return cfg;
+  }
+
+  static DemoTopology configureMock() {
+    return configureMock(false);
   }
 
   static void shutDown() {

--- a/src/test/java/org/scion/demo/PingPongChannelClient.java
+++ b/src/test/java/org/scion/demo/PingPongChannelClient.java
@@ -60,6 +60,14 @@ public class PingPongChannelClient {
   public static void main(String[] args) throws IOException, InterruptedException {
     // Demo setup
     switch (NETWORK) {
+      case MOCK_TOPOLOGY_IPV4:
+        {
+          DemoTopology.configureMock(true);
+          MockDNS.install("1-ff00:0:112", "localhost", "127.0.0.1");
+          doClientStuff(DemoConstants.ia112);
+          DemoTopology.shutDown();
+          break;
+        }
       case MOCK_TOPOLOGY:
         {
           DemoTopology.configureMock();
@@ -92,7 +100,6 @@ public class PingPongChannelClient {
     DatagramChannel channel = startClient();
     String msg = "Hello scion";
     InetSocketAddress serverAddress = PingPongChannelServer.getServerAddress(NETWORK);
-    // ScionSocketAddress serverAddress = ScionSocketAddress.create(isdAs, "::1", 44444);
     Path path = Scion.defaultService().getPaths(destinationIA, serverAddress).get(0);
 
     sendMessage(channel, msg, path);

--- a/src/test/java/org/scion/demo/PingPongChannelServer.java
+++ b/src/test/java/org/scion/demo/PingPongChannelServer.java
@@ -31,6 +31,7 @@ public class PingPongChannelServer {
       case MOCK_TOPOLOGY:
       case TINY_PROTO:
         return new InetSocketAddress("::1", SERVER_PORT);
+      case MOCK_TOPOLOGY_IPV4:
       case MINIMAL_PROTO:
         return new InetSocketAddress("127.0.0.1", SERVER_PORT);
       default:

--- a/src/test/java/org/scion/demo/PingPongDemoTest.java
+++ b/src/test/java/org/scion/demo/PingPongDemoTest.java
@@ -26,9 +26,9 @@ public class PingPongDemoTest {
   public void test() throws InterruptedException {
     AtomicInteger failures = new AtomicInteger();
     PingPongChannelServer.PRINT = false;
-    PingPongChannelServer.NETWORK = DemoConstants.Network.MOCK_TOPOLOGY;
+    PingPongChannelServer.NETWORK = DemoConstants.Network.MOCK_TOPOLOGY_IPV4;
     PingPongChannelClient.PRINT = false;
-    PingPongChannelClient.NETWORK = DemoConstants.Network.MOCK_TOPOLOGY;
+    PingPongChannelClient.NETWORK = DemoConstants.Network.MOCK_TOPOLOGY_IPV4;
     Thread server =
         new Thread(
             () -> {

--- a/src/test/java/org/scion/demo/PingPongDemoTest.java
+++ b/src/test/java/org/scion/demo/PingPongDemoTest.java
@@ -18,9 +18,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.scion.ScionService;
 
 public class PingPongDemoTest {
+
+  @BeforeAll
+  public static void beforeAll() {
+    ScionService.closeDefault();
+  }
 
   @Test
   public void test() throws InterruptedException {


### PR DESCRIPTION
CI builds fail with 

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.scion.api.DatagramChannelMultiSendPathTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.829 s -- in org.scion.api.DatagramChannelMultiSendPathTest
[INFO] Running org.scion.api.DatagramChannelApiTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.694 s -- in org.scion.api.DatagramChannelApiTest
[INFO] Running org.scion.api.ScionUtilTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in org.scion.api.ScionUtilTest
[INFO] Running org.scion.api.ScionServiceTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in org.scion.api.ScionServiceTest
[INFO] Running org.scion.api.SCMPTest
Common Header:   VER=0  TrafficClass=0  FlowID=1  NextHdr=202  HdrLen=35/140  PayloadLen=176  PathType=1  DT=0  DL=0  ST=0  SL=0  RSV=0
Address Header:   dstIsdAs=64-2:0:9  srcIsdAs=64-2:0:9  dstHost=0/-127.-124.-26.86  srcHost=0/-64.-88.53.20
Path header:   currINF=1  currHP=6  reserved=0  seg0Len=5  seg1Len=2  seg2Len=0
  info0=InfoField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, P=false, C=true, reserved=0, segID=18926, timestamp=1705419828}
  info1=InfoField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, P=false, C=true, reserved=0, segID=41450, timestamp=1705420185}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=0, consEgress=1, mac=186828329277865}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=1, consEgress=2, mac=200711980372373}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=1, consEgress=22, mac=188284819111107}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=3, consEgress=8, mac=176325508262598}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=21, consEgress=0, mac=112232581592721}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=0, consEgress=5, mac=204967725885794}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=1, consEgress=0, mac=85705461753766}
UdpOverlayHeader{srcPort=0, dstPort=0, length=0, checkSum=0}
Payload: null

Warning:  Tests run: 8, Failures: 0, Errors: 0, Skipped: 6, Time elapsed: 0.012 s -- in org.scion.api.SCMPTest
[INFO] Running org.scion.api.DatagramChannelStreamTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s -- in org.scion.api.DatagramChannelStreamTest
[INFO] Running org.scion.api.DatagramChannelMultiWriteConnectedInetSocketTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.112 s -- in org.scion.api.DatagramChannelMultiWriteConnectedInetSocketTest
[INFO] Running org.scion.api.DatagramChannelMultiSendInetAddrTest
Warning:  Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s -- in org.scion.api.DatagramChannelMultiSendInetAddrTest
[INFO] Running org.scion.api.DatagramChannelMultiWriteConnectedPathTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 s -- in org.scion.api.DatagramChannelMultiWriteConnectedPathTest
[INFO] Running org.scion.api.DatagramChannelPathSwitchTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 s -- in org.scion.api.DatagramChannelPathSwitchTest
[INFO] Running org.scion.api.DatagramSocketPingPongTest
Warning:  Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s -- in org.scion.api.DatagramSocketPingPongTest
[INFO] Running org.scion.api.ScionTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.194 s -- in org.scion.api.ScionTest
[INFO] Running org.scion.api.DatagramChannelPacketValidationTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s -- in org.scion.api.DatagramChannelPacketValidationTest
[INFO] Running org.scion.internal.SegmentsMinimal1111Test
Path header:   currINF=0  currHP=0  reserved=0  seg0Len=3  seg1Len=0  seg2Len=0
  info0=InfoField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, P=false, C=false, reserved=0, segID=58253, timestamp=1704902125}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=123, consEgress=0, mac=250766640027523}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=111, consEgress=1111, mac=131366165626801}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=0, consEgress=2, mac=13584673717625}
Hops: [c0:false c1:false c2:false 123>1111 111>2 ]
Hops: [c0:false c1:false c2:false 123>1111 111>2 ]
Path header:   currINF=0  currHP=0  reserved=0  seg0Len=3  seg1Len=0  seg2Len=0
  info0=InfoField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, P=false, C=false, reserved=0, segID=10619, timestamp=1707235414}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=123, consEgress=0, mac=1108152157446}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=111, consEgress=1111, mac=1108152157446}
    hop=HopField{r0=false, r1=false, r2=false, r3=false, r4=false, r5=false, r6=false, I=false, E=false, expiryTime=63, consIngress=0, consEgress=2, mac=1108152157446}
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in org.scion.internal.SegmentsMinimal1111Test
[INFO] Running org.scion.internal.SegmentsMinimal110Test
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in org.scion.internal.SegmentsMinimal110Test
[INFO] Running org.scion.internal.SegmentsMinimal111Test
Warning:  Tests run: 8, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.059 s -- in org.scion.internal.SegmentsMinimal111Test
[INFO] Running org.scion.internal.InspectorComposeTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s -- in org.scion.internal.InspectorComposeTest
[INFO] Running org.scion.internal.InspectorParseAndReplyTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in org.scion.internal.InspectorParseAndReplyTest
[INFO] Running org.scion.internal.SegmentsDefaultTest
Warning:  Tests run: 7, Failures: 0, Errors: 0, Skipped: 7, Time elapsed: 0 s -- in org.scion.internal.SegmentsDefaultTest
[INFO] Running org.scion.internal.HeaderComposeTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in org.scion.internal.HeaderComposeTest
[INFO] Running org.scion.internal.ByteUtilTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in org.scion.internal.ByteUtilTest
[INFO] Running org.scion.internal.SegmentsMinimal120Test
Warning:  Tests run: 2, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0 s -- in org.scion.internal.SegmentsMinimal120Test
[INFO] Running org.scion.internal.InspectorParseAndDuplicateTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in org.scion.internal.InspectorParseAndDuplicateTest
[INFO] Running org.scion.internal.HeaderParseAndReplyTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in org.scion.internal.HeaderParseAndReplyTest
[INFO] Running org.scion.internal.SegmentsTinyTest
Warning:  Tests run: 8, Failures: 0, Errors: 0, Skipped: 8, Time elapsed: 0 s -- in org.scion.internal.SegmentsTinyTest
[INFO] Running org.scion.demo.util.ToStringUtilTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in org.scion.demo.util.ToStringUtilTest
[INFO] Running org.scion.demo.PingPongDemoTest
Error: Exception in thread "BorderRouter-1" org.scion.ScionRuntimeException: Error while getting Segments: cannot connect to SCION network
	at org.scion.internal.Segments.getSegments(Segments.java:462)
	at org.scion.internal.Segments.getPaths(Segments.java:522)
	at org.scion.ScionService.getPathListCS(ScionService.java:472)
	at org.scion.ScionService.getPathList(ScionService.java:250)
	at org.scion.ScionService.getPaths(ScionService.java:315)
	at org.scion.ScionService.getPaths(ScionService.java:291)
	at org.scion.demo.PingPongChannelClient.doClientStuff(PingPongChannelClient.java:96)
	at org.scion.demo.PingPongChannelClient.main(PingPongChannelClient.java:67)
	at org.scion.demo.PingPongDemoTest.lambda$test$1(PingPongDemoTest.java:50)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusRuntimeException: UNAVAILABLE: Channel shutdown invoked
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:268)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:249)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:167)
	at org.scion.proto.control_plane.SegmentLookupServiceGrpc$SegmentLookupServiceBlockingStub.segments(SegmentLookupServiceGrpc.java:169)
	at org.scion.internal.Segments.getSegments(Segments.java:448)
	... 9 more
Error: Exception in thread "Thread-198" java.lang.RuntimeException: java.nio.channels.ClosedByInterruptException
	at org.scion.demo.PingPongDemoTest.lambda$test$0(PingPongDemoTest.java:39)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.nio.channels.ClosedByInterruptException
	at java.base/java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:199)
	at java.base/sun.nio.ch.DatagramChannelImpl.endRead(DatagramChannelImpl.java:397)
	at java.base/sun.nio.ch.DatagramChannelImpl.receive(DatagramChannelImpl.java:454)
	at org.scion.DatagramChannel.receiveFromChannel(DatagramChannel.java:215)
	at org.scion.DatagramChannel.receive(DatagramChannel.java:194)
	at org.scion.demo.PingPongChannelServer.receiveMessage(PingPongChannelServer.java:66)
	at org.scion.demo.PingPongChannelServer.main(PingPongChannelServer.java:85)
	at org.scion.demo.PingPongDemoTest.lambda$test$0(PingPongDemoTest.java:36)
	... 1 more
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.005 s -- in org.scion.demo.PingPongDemoTest
[INFO] Running org.scion.demo.inspector.ScmpTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in org.scion.demo.inspector.ScmpTest
[INFO] Running org.scion.demo.inspector.ScionPacketInspectorTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in org.scion.demo.inspector.ScionPacketInspectorTest
[INFO] Running org.scion.testutil.PingPongHelperTest
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.010 s <<< FAILURE! -- in org.scion.testutil.PingPongHelperTest
Error:  org.scion.testutil.PingPongHelperTest.test -- Time elapsed: 0.008 s <<< ERROR!
java.lang.IllegalStateException
	at org.scion.testutil.MockNetwork.startTiny(MockNetwork.java:65)
	at org.scion.testutil.MockNetwork.startTiny(MockNetwork.java:60)
	at org.scion.testutil.PingPongHelper.runPingPong(PingPongHelper.java:144)
	at org.scion.testutil.PingPongHelper.runPingPong(PingPongHelper.java:139)
	at org.scion.testutil.PingPongHelperTest.test(PingPongHelperTest.java:26)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

[INFO] Running org.scion.ScionBootstrapperTest
Warning:  Tests run: 3, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.002 s -- in org.scion.ScionBootstrapperTest
[INFO] Running protobuf.SmokeTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in protobuf.SmokeTest
[INFO] 
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:    PingPongHelperTest.test:26 » IllegalState
[INFO] 
Error:  Tests run: 126, Failures: 0, Errors: 1, Skipped: 29
```