### PR TITLE
SCMP refactoring and clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - BREAKING CHANGE: Changed maven artifactId to "client"
   [#9](https://github.com/tzaeschke/phtree-cpp/pull/9)
+- BREAKING CHANGE: SCMP refactoring, renamed several SCMP related classes.
+  [#14](https://github.com/tzaeschke/phtree-cpp/pull/14)
 
 ### Fixed
 - Fixed SCMP timeout and error handling (IOExceptions + SCMP errors).

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ The central classes of the API are:
   returned by `Scion.defaultService()`.
 - `Scion`, `ScionUtil`, `ScionConstants`: Utility classes.
 - `ScionSocketOptions`: Options for the `DatagramChannel`.
-- `SCMP` provides `ScmpType` and `ScmpCode` enums with text messages. It also contains
-  `ScmpMessage` (for SCMP errors) and `ScmpEcho`/`ScmpTraceroute` types. These can be used with the
-  `DatagramChannel`'s `sendXXXRequest()` and `setXXXListener()` methods.
+- `Scmp`:
+  - `ScmpType` and `ScmpCode` enums with text messages. 
+  - `Message` (for SCMP errors) and `EchoMessage`/`TracerouteMessage` types.
+  - `createChannel(...)` for sending echo and traceroute requests
 - **TODO** Currently residing in `test`: `ScionPacketInspector`: A packet inspector and builder.
 - **TODO** `DatagramSocket` and `DatagramPacket`: These work similar to the old `java.net.DatagramSocket`.
   This is currently deprecated because it does not work well.

--- a/TODO.md
+++ b/TODO.md
@@ -94,6 +94,7 @@ Discuss required for 0.1.0:
 - Selector support
   - Implement interfaces from nio.DatagramChannel
   - Look into Selectors:  https://www.baeldung.com/java-nio-selector
+- Consider sublcassing DatagramChannel directly. 
 - Consider SHIM support. SHIM is a compatibility component that supports
   old border-router software (requiring a fixed port on the client, unless
   the client is listening on this very port).  When SHIM is used, we cannot 

--- a/doc/Design.md
+++ b/doc/Design.md
@@ -8,6 +8,7 @@ We should look at other custom Java protocol implementations, e.g. for QUIC:
 ## Daemon
 The implementation can use the daemon. Alternatively, since daemon installation may
 be cumbersome on platforms such as Android, we can directly connect to a control service.
+
 An alternative for mobile devices could be a non-local daemon that is hosted by the mobile provider.
 This may work but may open opportunities for side-channel attacks on the daemon.
 Also, when roaming, the provider may not actually support SCION. In this case the
@@ -27,7 +28,7 @@ at least a topology server + control server.
 - Use Junit 5.
 - Use Google style guide for code
 - We use custom exceptions. However, to make the API as compatible with standard networking API
-  as possible, our Exceptions extend either IOException or RuntimeExcdeption.
+  as possible, our Exceptions extends either IOException or RuntimeException.
 
 ## Paths
 

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -179,6 +179,10 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     return path;
   }
 
+  protected void setPath(RequestPath path) {
+    this.path = path;
+  }
+
   protected ResponsePath receiveFromChannel(
       ByteBuffer buffer, InternalConstants.HdrTypes expectedHdrType) throws IOException {
     while (true) {

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -1,0 +1,427 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.AlreadyConnectedException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.NotYetConnectedException;
+import java.time.Instant;
+import java.util.function.Consumer;
+import org.scion.internal.ExtensionHeader;
+import org.scion.internal.InternalConstants;
+import org.scion.internal.ScionHeaderParser;
+import org.scion.internal.ScmpParser;
+
+abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> implements Closeable {
+
+  private final java.nio.channels.DatagramChannel channel;
+  private boolean isConnected = false;
+  private InetSocketAddress connection;
+  private RequestPath path;
+  private boolean cfgReportFailedValidation = false;
+  private PathPolicy pathPolicy = PathPolicy.DEFAULT;
+  private ScionService service;
+  private int cfgExpirationSafetyMargin =
+      ScionUtil.getPropertyOrEnv(
+          Constants.PROPERTY_PATH_EXPIRY_MARGIN,
+          Constants.ENV_PATH_EXPIRY_MARGIN,
+          Constants.DEFAULT_PATH_EXPIRY_MARGIN);
+
+  private Consumer<Scmp.EchoResult> pingListener;
+  private Consumer<Scmp.TracerouteResult> traceListener;
+  private Consumer<Scmp.Message> errorListener;
+
+  protected AbstractDatagramChannel(ScionService service) throws IOException {
+    this.channel = java.nio.channels.DatagramChannel.open();
+    this.service = service;
+  }
+
+  protected synchronized void configureBlocking(boolean block) throws IOException {
+    channel.configureBlocking(block);
+  }
+
+  protected synchronized boolean isBlocking() {
+    return channel.isBlocking();
+  }
+
+  /**
+   * Set the path policy. The default path policy is set in PathPolicy.DEFAULT, which currently
+   * means to use the first path returned by the daemon or control service. If the channel is
+   * connected, this method will request a new path using the new policy.
+   *
+   * @param pathPolicy the new path policy
+   * @see PathPolicy#DEFAULT
+   */
+  public synchronized void setPathPolicy(PathPolicy pathPolicy) throws IOException {
+    this.pathPolicy = pathPolicy;
+    if (path != null) {
+      updatePath(path);
+    }
+  }
+
+  public synchronized PathPolicy getPathPolicy() {
+    return this.pathPolicy;
+  }
+
+  public synchronized void setService(ScionService service) {
+    this.service = service;
+  }
+
+  public synchronized ScionService getService() {
+    if (service == null) {
+      service = Scion.defaultService();
+    }
+    return this.service;
+  }
+
+  protected DatagramChannel channel() {
+    return channel;
+  }
+
+  @SuppressWarnings("unchecked")
+  public synchronized C bind(InetSocketAddress address) throws IOException {
+    channel.bind(address);
+    return (C) this;
+  }
+
+  public synchronized InetSocketAddress getLocalAddress() throws IOException {
+    return (InetSocketAddress) channel.getLocalAddress();
+  }
+
+  public synchronized void disconnect() throws IOException {
+    channel.disconnect();
+    connection = null;
+    isConnected = false;
+    path = null;
+  }
+
+  public synchronized boolean isOpen() {
+    return channel.isOpen();
+  }
+
+  @Override
+  // TODO not synchronized yet, think about a more fine grained lock (see JDK Channel impl)
+  public void close() throws IOException {
+    channel.disconnect();
+    channel.close();
+    isConnected = false;
+    connection = null;
+    path = null;
+  }
+
+  /**
+   * Connect to a destination host. Note: - A SCION channel will internally connect to the next
+   * border router (first hop) instead of the remote host.
+   *
+   * <p>NB: This method does internally no call {@link java.nio.channels.DatagramChannel}.connect(),
+   * instead it calls bind(). That means this method does NOT perform any additional security checks
+   * associated with connect(), only those associated with bind().
+   *
+   * @param addr Address of remote host.
+   * @return This channel.
+   * @throws IOException for example when the first hop (border router) cannot be connected.
+   */
+  public synchronized C connect(SocketAddress addr) throws IOException {
+    checkConnected(false);
+    if (!(addr instanceof InetSocketAddress)) {
+      throw new IllegalArgumentException(
+          "connect() requires an InetSocketAddress or a ScionSocketAddress.");
+    }
+    return connect(pathPolicy.filter(getService().getPaths((InetSocketAddress) addr)));
+  }
+
+  /**
+   * Connect to a destination host. Note: - A SCION channel will internally connect to the next
+   * border router (first hop) instead of the remote host. - The path will be replaced with a new
+   * path once it is expired.
+   *
+   * <p>NB: This method does internally no call {@link java.nio.channels.DatagramChannel}.connect(),
+   * instead it calls bind(). That means this method does NOT perform any additional security checks
+   * associated with connect(), only those associated with bind().
+   *
+   * @param path Path to the remote host.
+   * @return This channel.
+   * @throws IOException for example when the first hop (border router) cannot be connected.
+   */
+  @SuppressWarnings("unchecked")
+  public synchronized C connect(RequestPath path) throws IOException {
+    checkConnected(false);
+    this.path = path;
+    isConnected = true;
+    connection = path.getFirstHopAddress();
+    channel.connect(connection);
+    return (C) this;
+  }
+
+  /**
+   * Get the currently connected path.
+   *
+   * @return the current Path or `null` if not path is connected.
+   */
+  public synchronized Path getCurrentPath() {
+    return path;
+  }
+
+  protected ResponsePath receiveFromChannel(
+      ByteBuffer buffer, InternalConstants.HdrTypes expectedHdrType) throws IOException {
+    while (true) {
+      buffer.clear();
+      InetSocketAddress srcAddress = (InetSocketAddress) channel.receive(buffer);
+      if (srcAddress == null) {
+        // this indicates nothing is available - non-blocking mode
+        return null;
+      }
+      buffer.flip();
+
+      String validationResult = ScionHeaderParser.validate(buffer.asReadOnlyBuffer());
+      if (validationResult != null) {
+        if (cfgReportFailedValidation) {
+          throw new ScionException(validationResult);
+        }
+        continue;
+      }
+
+      InternalConstants.HdrTypes hdrType = ScionHeaderParser.extractNextHeader(buffer);
+      if (expectedHdrType == hdrType && hdrType == InternalConstants.HdrTypes.UDP) {
+        return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
+      }
+
+      // From here on we use linear reading using the buffer's position() mechanism
+      buffer.position(ScionHeaderParser.extractHeaderLength(buffer));
+      if (hdrType == InternalConstants.HdrTypes.END_TO_END
+          || hdrType == InternalConstants.HdrTypes.HOP_BY_HOP) {
+        ExtensionHeader extHdr = ExtensionHeader.consume(buffer);
+        // Currently we are not doing much here except hoping for an SCMP header
+        hdrType = extHdr.nextHdr();
+        if (hdrType != InternalConstants.HdrTypes.SCMP) {
+          throw new UnsupportedOperationException("Extension header not supported: " + hdrType);
+        }
+      }
+
+      if (hdrType == expectedHdrType) {
+        return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
+      }
+      receiveScmp(buffer, path);
+    }
+  }
+
+  private Object receiveNonDataPacket(
+      ByteBuffer buffer, InternalConstants.HdrTypes hdrType, ResponsePath path)
+      throws ScionException {
+    switch (hdrType) {
+      case HOP_BY_HOP:
+      case END_TO_END:
+        return receiveExtension(buffer, path);
+      case SCMP:
+        return receiveScmp(buffer, path);
+      default:
+        if (cfgReportFailedValidation) {
+          throw new ScionException("Unknown nextHdr: " + hdrType);
+        }
+    }
+    return null;
+  }
+
+  private Object receiveExtension(ByteBuffer buffer, ResponsePath path) throws ScionException {
+    ExtensionHeader extHdr = ExtensionHeader.consume(buffer);
+    // Currently we are not doing much here except hoping for an SCMP header
+    return receiveNonDataPacket(buffer, extHdr.nextHdr(), path);
+  }
+
+  private Scmp.Message receiveScmp(ByteBuffer buffer, Path path) {
+    Scmp.Message scmpMsg = ScmpParser.consume(buffer, path);
+    checkListeners(scmpMsg);
+    return scmpMsg;
+  }
+
+  protected void checkListeners(Scmp.Message scmpMsg) {
+    if (scmpMsg instanceof Scmp.EchoResult) {
+      if (pingListener != null) {
+        pingListener.accept((Scmp.EchoResult) scmpMsg);
+      }
+    } else if (scmpMsg instanceof Scmp.TracerouteResult) {
+      if (traceListener != null) {
+        traceListener.accept((Scmp.TracerouteResult) scmpMsg);
+      }
+    } else {
+      if (errorListener != null) {
+        errorListener.accept(scmpMsg);
+      }
+    }
+  }
+
+  void sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {
+    channel.send(buffer, address);
+  }
+
+  public synchronized Consumer<Scmp.EchoResult> setEchoListener(
+      Consumer<Scmp.EchoResult> listener) {
+    Consumer<Scmp.EchoResult> old = pingListener;
+    pingListener = listener;
+    return old;
+  }
+
+  public synchronized Consumer<Scmp.TracerouteResult> setTracerouteListener(
+      Consumer<Scmp.TracerouteResult> listener) {
+    Consumer<Scmp.TracerouteResult> old = traceListener;
+    traceListener = listener;
+    return old;
+  }
+
+  public synchronized Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {
+    Consumer<Scmp.Message> old = errorListener;
+    errorListener = listener;
+    return old;
+  }
+
+  protected void checkOpen() throws ClosedChannelException {
+    if (!channel.isOpen()) {
+      throw new ClosedChannelException();
+    }
+  }
+
+  protected void checkConnected(boolean requiredState) {
+    if (requiredState != isConnected) {
+      if (isConnected) {
+        throw new AlreadyConnectedException();
+      } else {
+        throw new NotYetConnectedException();
+      }
+    }
+  }
+
+  public synchronized boolean isConnected() {
+    return isConnected;
+  }
+
+  @SuppressWarnings("unchecked")
+  public synchronized <T> T getOption(SocketOption<T> option) throws IOException {
+    if (option instanceof ScionSocketOptions.SciSocketOption) {
+      if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
+        return (T) (Boolean) cfgReportFailedValidation;
+      } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
+        return (T) (Integer) cfgExpirationSafetyMargin;
+      } else {
+        throw new UnsupportedOperationException();
+      }
+    }
+    return channel.getOption(option);
+  }
+
+  @SuppressWarnings("unchecked")
+  public synchronized <T> C setOption(SocketOption<T> option, T t) throws IOException {
+    if (option instanceof ScionSocketOptions.SciSocketOption) {
+      if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
+        cfgReportFailedValidation = (Boolean) t;
+      } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
+        cfgExpirationSafetyMargin = (Integer) t;
+      } else {
+        throw new UnsupportedOperationException();
+      }
+    } else if (StandardSocketOptions.SO_RCVBUF.equals(option)) {
+      // TODO resize buf
+      channel.setOption(option, t);
+    } else if (StandardSocketOptions.SO_SNDBUF.equals(option)) {
+      // TODO resize buf
+      channel.setOption(option, t);
+    } else {
+      channel.setOption(option, t);
+    }
+    return (C) this;
+  }
+
+  /**
+   * @param path path
+   * @param payloadLength payload length
+   * @return argument path or a new path if the argument path was expired
+   * @throws IOException in case of IOException.
+   */
+  protected Path buildHeader(
+      ByteBuffer buffer, Path path, int payloadLength, InternalConstants.HdrTypes hdrType)
+      throws IOException {
+    buffer.clear();
+    long srcIA;
+    byte[] srcAddress;
+    int srcPort;
+    if (path instanceof ResponsePath) {
+      // We could get source IA, address and port locally, but it seems cleaner
+      // to get these from the inverted header.
+      ResponsePath rPath = (ResponsePath) path;
+      srcIA = rPath.getSourceIsdAs();
+      srcAddress = rPath.getSourceAddress();
+      srcPort = rPath.getSourcePort();
+    } else {
+      // For sending request path we need to have a valid local external address.
+      // For a valid local external address we need to be connected.
+      if (!isConnected) {
+        isConnected = true;
+        connection = path.getFirstHopAddress();
+        channel.connect(connection);
+      }
+
+      // check path expiration
+      path = ensureUpToDate((RequestPath) path);
+      srcIA = getService().getLocalIsdAs();
+      // Get external host address. This must be done *after* refreshing the path!
+      InetSocketAddress srcSocketAddress = (InetSocketAddress) channel.getLocalAddress();
+      srcAddress = srcSocketAddress.getAddress().getAddress();
+      srcPort = srcSocketAddress.getPort();
+    }
+
+    long dstIA = path.getDestinationIsdAs();
+    byte[] dstAddress = path.getDestinationAddress();
+    int dstPort = path.getDestinationPort();
+
+    byte[] rawPath = path.getRawPath();
+    ScionHeaderParser.write(
+        buffer, payloadLength, rawPath.length, srcIA, srcAddress, dstIA, dstAddress, hdrType);
+    ScionHeaderParser.writePath(buffer, rawPath);
+
+    // TODO move this outside of this method
+    if (hdrType == InternalConstants.HdrTypes.UDP) {
+      ScionHeaderParser.writeUdpOverlayHeader(buffer, payloadLength, srcPort, dstPort);
+    }
+
+    return path;
+  }
+
+  private Path ensureUpToDate(RequestPath path) throws IOException {
+    if (Instant.now().getEpochSecond() + cfgExpirationSafetyMargin <= path.getExpiration()) {
+      return path;
+    }
+    return updatePath(path);
+  }
+
+  private Path updatePath(RequestPath path) throws IOException {
+    // expired, get new path
+    RequestPath newPath = pathPolicy.filter(getService().getPaths(path));
+
+    if (isConnected) { // equal to !isBound at this point
+      if (!newPath.getFirstHopAddress().equals(this.connection)) {
+        // TODO only reconnect if firstHop is on different interface....?!
+        channel.disconnect();
+        this.connection = newPath.getFirstHopAddress();
+        channel.connect(this.connection);
+      }
+      this.path = newPath;
+    }
+    return newPath;
+  }
+}

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -44,8 +44,8 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
           Constants.ENV_PATH_EXPIRY_MARGIN,
           Constants.DEFAULT_PATH_EXPIRY_MARGIN);
 
-  private Consumer<Scmp.EchoPacket> pingListener;
-  private Consumer<Scmp.TraceroutePacket> traceListener;
+  private Consumer<Scmp.EchoMessage> pingListener;
+  private Consumer<Scmp.TracerouteMessage> traceListener;
   private Consumer<Scmp.Message> errorListener;
 
   protected AbstractDatagramChannel(ScionService service) throws IOException {
@@ -203,21 +203,13 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
       }
 
       InternalConstants.HdrTypes hdrType = ScionHeaderParser.extractNextHeader(buffer);
-      if (expectedHdrType == hdrType && hdrType == InternalConstants.HdrTypes.UDP) {
-        return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
-      }
 
       // From here on we use linear reading using the buffer's position() mechanism
       buffer.position(ScionHeaderParser.extractHeaderLength(buffer));
-      if (hdrType == InternalConstants.HdrTypes.END_TO_END
-          || hdrType == InternalConstants.HdrTypes.HOP_BY_HOP) {
-        ExtensionHeader extHdr = ExtensionHeader.consume(buffer);
-        // Currently we are not doing much here except hoping for an SCMP header
-        hdrType = extHdr.nextHdr();
-        if (hdrType != InternalConstants.HdrTypes.SCMP) {
-          throw new UnsupportedOperationException("Extension header not supported: " + hdrType);
-        }
-      }
+      // Check for extension headers.
+      // This should be mostly unnecessary, however we sometimes saw SCMP error headers wrapped
+      // in extensions headers.
+      hdrType = receiveExtensionHeader(buffer, hdrType);
 
       if (hdrType == expectedHdrType) {
         return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
@@ -226,42 +218,65 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     }
   }
 
-  private Scmp.Message receiveScmp(ByteBuffer buffer, Path path) {
-    Scmp.Message scmpMsg = ScmpParser.consume(buffer, path);
-    checkListeners(scmpMsg);
-    return scmpMsg;
+  private InternalConstants.HdrTypes receiveExtensionHeader(
+      ByteBuffer buffer, InternalConstants.HdrTypes hdrType) {
+    if (hdrType == InternalConstants.HdrTypes.END_TO_END
+        || hdrType == InternalConstants.HdrTypes.HOP_BY_HOP) {
+      ExtensionHeader extHdr = ExtensionHeader.consume(buffer);
+      // Currently we are not doing much here except hoping for an SCMP header
+      hdrType = extHdr.nextHdr();
+      if (hdrType != InternalConstants.HdrTypes.SCMP) {
+        throw new UnsupportedOperationException("Extension header not supported: " + hdrType);
+      }
+    }
+    return hdrType;
   }
 
-  protected void checkListeners(Scmp.Message scmpMsg) {
-    if (scmpMsg instanceof Scmp.EchoPacket && !scmpMsg.getTypeCode().isError()) {
+  private Scmp.Message receiveScmp(ByteBuffer buffer, Path path) {
+    Scmp.ScmpType type = ScmpParser.extractType(buffer);
+    switch (type) {
+      case INFO_128:
+      case INFO_129:
+        return checkListeners(ScmpParser.consume(buffer, Scmp.EchoMessage.createEmpty(path)));
+      case INFO_130:
+      case INFO_131:
+        return checkListeners(ScmpParser.consume(buffer, Scmp.TracerouteMessage.createEmpty(path)));
+      default:
+        return checkListeners(ScmpParser.consume(buffer, new Scmp.Message(null, -1, -1, path)));
+    }
+  }
+
+  protected Scmp.Message checkListeners(Scmp.Message scmpMsg) {
+    if (scmpMsg instanceof Scmp.EchoMessage && !scmpMsg.getTypeCode().isError()) {
       if (pingListener != null) {
-        pingListener.accept((Scmp.EchoPacket) scmpMsg);
+        pingListener.accept((Scmp.EchoMessage) scmpMsg);
       }
-    } else if (scmpMsg instanceof Scmp.TraceroutePacket && !scmpMsg.getTypeCode().isError()) {
+    } else if (scmpMsg instanceof Scmp.TracerouteMessage && !scmpMsg.getTypeCode().isError()) {
       if (traceListener != null) {
-        traceListener.accept((Scmp.TraceroutePacket) scmpMsg);
+        traceListener.accept((Scmp.TracerouteMessage) scmpMsg);
       }
     } else {
       if (errorListener != null) {
         errorListener.accept(scmpMsg);
       }
     }
+    return scmpMsg;
   }
 
-  void sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {
+  protected void sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {
     channel.send(buffer, address);
   }
 
-  public synchronized Consumer<Scmp.EchoPacket> setEchoListener(
-      Consumer<Scmp.EchoPacket> listener) {
-    Consumer<Scmp.EchoPacket> old = pingListener;
+  protected synchronized Consumer<Scmp.EchoMessage> setEchoListener(
+      Consumer<Scmp.EchoMessage> listener) {
+    Consumer<Scmp.EchoMessage> old = pingListener;
     pingListener = listener;
     return old;
   }
 
-  public synchronized Consumer<Scmp.TraceroutePacket> setTracerouteListener(
-      Consumer<Scmp.TraceroutePacket> listener) {
-    Consumer<Scmp.TraceroutePacket> old = traceListener;
+  protected synchronized Consumer<Scmp.TracerouteMessage> setTracerouteListener(
+      Consumer<Scmp.TracerouteMessage> listener) {
+    Consumer<Scmp.TracerouteMessage> old = traceListener;
     traceListener = listener;
     return old;
   }

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -43,9 +43,6 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
           Constants.PROPERTY_PATH_EXPIRY_MARGIN,
           Constants.ENV_PATH_EXPIRY_MARGIN,
           Constants.DEFAULT_PATH_EXPIRY_MARGIN);
-
-  private Consumer<Scmp.EchoMessage> pingListener;
-  private Consumer<Scmp.TracerouteMessage> traceListener;
   private Consumer<Scmp.Message> errorListener;
 
   protected AbstractDatagramChannel(ScionService service) throws IOException {
@@ -238,37 +235,13 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   }
 
   protected void checkListeners(Scmp.Message scmpMsg) {
-    if (scmpMsg instanceof Scmp.EchoMessage && !scmpMsg.getTypeCode().isError()) {
-      if (pingListener != null) {
-        pingListener.accept((Scmp.EchoMessage) scmpMsg);
-      }
-    } else if (scmpMsg instanceof Scmp.TracerouteMessage && !scmpMsg.getTypeCode().isError()) {
-      if (traceListener != null) {
-        traceListener.accept((Scmp.TracerouteMessage) scmpMsg);
-      }
-    } else {
-      if (errorListener != null) {
-        errorListener.accept(scmpMsg);
-      }
+    if (errorListener != null && scmpMsg.getTypeCode().isError()) {
+      errorListener.accept(scmpMsg);
     }
   }
 
   protected void sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {
     channel.send(buffer, address);
-  }
-
-  protected synchronized Consumer<Scmp.EchoMessage> setEchoListener(
-      Consumer<Scmp.EchoMessage> listener) {
-    Consumer<Scmp.EchoMessage> old = pingListener;
-    pingListener = listener;
-    return old;
-  }
-
-  protected synchronized Consumer<Scmp.TracerouteMessage> setTracerouteListener(
-      Consumer<Scmp.TracerouteMessage> listener) {
-    Consumer<Scmp.TracerouteMessage> old = traceListener;
-    traceListener = listener;
-    return old;
   }
 
   public synchronized Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -252,11 +252,11 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   }
 
   protected void checkListeners(Scmp.Message scmpMsg) {
-    if (scmpMsg instanceof Scmp.EchoResult) {
+    if (scmpMsg instanceof Scmp.EchoResult && !scmpMsg.getTypeCode().isError()) {
       if (pingListener != null) {
         pingListener.accept((Scmp.EchoResult) scmpMsg);
       }
-    } else if (scmpMsg instanceof Scmp.TracerouteResult) {
+    } else if (scmpMsg instanceof Scmp.TracerouteResult && !scmpMsg.getTypeCode().isError()) {
       if (traceListener != null) {
         traceListener.accept((Scmp.TracerouteResult) scmpMsg);
       }

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -232,21 +232,12 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     return hdrType;
   }
 
-  private Scmp.Message receiveScmp(ByteBuffer buffer, Path path) {
+  private void receiveScmp(ByteBuffer buffer, Path path) {
     Scmp.ScmpType type = ScmpParser.extractType(buffer);
-    switch (type) {
-      case INFO_128:
-      case INFO_129:
-        return checkListeners(ScmpParser.consume(buffer, Scmp.EchoMessage.createEmpty(path)));
-      case INFO_130:
-      case INFO_131:
-        return checkListeners(ScmpParser.consume(buffer, Scmp.TracerouteMessage.createEmpty(path)));
-      default:
-        return checkListeners(ScmpParser.consume(buffer, new Scmp.Message(null, -1, -1, path)));
-    }
+    checkListeners(ScmpParser.consume(buffer, Scmp.createMessage(type, path)));
   }
 
-  protected Scmp.Message checkListeners(Scmp.Message scmpMsg) {
+  protected void checkListeners(Scmp.Message scmpMsg) {
     if (scmpMsg instanceof Scmp.EchoMessage && !scmpMsg.getTypeCode().isError()) {
       if (pingListener != null) {
         pingListener.accept((Scmp.EchoMessage) scmpMsg);
@@ -260,7 +251,6 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
         errorListener.accept(scmpMsg);
       }
     }
-    return scmpMsg;
   }
 
   protected void sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {

--- a/src/main/java/org/scion/DatagramChannel.java
+++ b/src/main/java/org/scion/DatagramChannel.java
@@ -18,37 +18,26 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
-import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ByteChannel;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NotYetConnectedException;
-import java.time.Instant;
-import java.util.function.Consumer;
-import org.scion.internal.ExtensionHeader;
 import org.scion.internal.InternalConstants;
-import org.scion.internal.PathHeaderParser;
 import org.scion.internal.ScionHeaderParser;
-import org.scion.internal.ScmpParser;
 
-public class DatagramChannel implements ByteChannel, Closeable {
+public class DatagramChannel extends AbstractDatagramChannel<DatagramChannel>
+    implements ByteChannel, Closeable {
 
-  private final java.nio.channels.DatagramChannel channel;
-  private boolean isConnected = false;
-  private InetSocketAddress connection;
-  private RequestPath path;
-  private final ByteBuffer buffer;
-  private boolean cfgReportFailedValidation = false;
-  private PathPolicy pathPolicy = PathPolicy.DEFAULT;
-  private ScionService service;
-  private int cfgExpirationSafetyMargin =
-      ScionUtil.getPropertyOrEnv(
-          Constants.PROPERTY_PATH_EXPIRY_MARGIN,
-          Constants.ENV_PATH_EXPIRY_MARGIN,
-          Constants.DEFAULT_PATH_EXPIRY_MARGIN);
+  private final ByteBuffer bufferReceive;
+  private final ByteBuffer bufferSend;
 
-  private Consumer<Scmp.EchoResult> pingListener;
-  private Consumer<Scmp.TracerouteResult> traceListener;
-  private Consumer<Scmp.Message> errorListener;
+  protected DatagramChannel() throws IOException {
+    this(null);
+  }
+
+  protected DatagramChannel(ScionService service) throws IOException {
+    super(service);
+    this.bufferReceive = ByteBuffer.allocateDirect(getOption(StandardSocketOptions.SO_RCVBUF));
+    this.bufferSend = ByteBuffer.allocateDirect(getOption(StandardSocketOptions.SO_SNDBUF));
+  }
 
   public static DatagramChannel open() throws IOException {
     return new DatagramChannel();
@@ -58,272 +47,26 @@ public class DatagramChannel implements ByteChannel, Closeable {
     return new DatagramChannel(service);
   }
 
-  protected DatagramChannel() throws IOException {
-    this(null);
-  }
-
-  protected DatagramChannel(ScionService service) throws IOException {
-    this.channel = java.nio.channels.DatagramChannel.open();
-    this.service = service;
-    // TODO snd/rcv
-    int size =
-        Math.max(
-            channel.getOption(StandardSocketOptions.SO_RCVBUF),
-            channel.getOption(StandardSocketOptions.SO_SNDBUF));
-    this.buffer = ByteBuffer.allocateDirect(size);
-  }
-
-  /**
-   * Set the path policy. The default path policy is set in PathPolicy.DEFAULT, which currently
-   * means to use the first path returned by the daemon or control service. If the channel is
-   * connected, this method will request a new path using the new policy.
-   *
-   * @param pathPolicy the new path policy
-   * @see PathPolicy#DEFAULT
-   */
-  public synchronized void setPathPolicy(PathPolicy pathPolicy) throws IOException {
-    this.pathPolicy = pathPolicy;
-    if (path != null) {
-      updatePath(path);
-    }
-  }
-
-  public synchronized PathPolicy getPathPolicy() {
-    return this.pathPolicy;
-  }
-
-  public synchronized void setService(ScionService service) {
-    this.service = service;
-  }
-
-  public synchronized ScionService getService() {
-    if (service == null) {
-      service = Scion.defaultService();
-    }
-    return this.service;
-  }
-
-  public synchronized DatagramChannel bind(InetSocketAddress address) throws IOException {
-    channel.bind(address);
-    return this;
-  }
-
   // TODO we return `void` here. If we implement SelectableChannel
   //  this can be changed to return SelectableChannel.
+  @Override
   public synchronized void configureBlocking(boolean block) throws IOException {
-    channel.configureBlocking(block);
+    super.configureBlocking(block);
   }
 
+  @Override
   public synchronized boolean isBlocking() {
-    return channel.isBlocking();
-  }
-
-  public synchronized InetSocketAddress getLocalAddress() throws IOException {
-    return (InetSocketAddress) channel.getLocalAddress();
-  }
-
-  public synchronized void disconnect() throws IOException {
-    channel.disconnect();
-    connection = null;
-    isConnected = false;
-    path = null;
-  }
-
-  @Override
-  public synchronized boolean isOpen() {
-    return channel.isOpen();
-  }
-
-  @Override
-  // TODO not synchronized yet, think about a more fine grained lock (see JDK Channel impl)
-  public void close() throws IOException {
-    channel.disconnect();
-    channel.close();
-    isConnected = false;
-    connection = null;
-    path = null;
-  }
-
-  /**
-   * Connect to a destination host. Note: - A SCION channel will internally connect to the next
-   * border router (first hop) instead of the remote host.
-   *
-   * <p>NB: This method does internally no call {@link java.nio.channels.DatagramChannel}.connect(),
-   * instead it calls bind(). That means this method does NOT perform any additional security checks
-   * associated with connect(), only those associated with bind().
-   *
-   * @param addr Address of remote host.
-   * @return This channel.
-   * @throws IOException for example when the first hop (border router) cannot be connected.
-   */
-  public synchronized DatagramChannel connect(SocketAddress addr) throws IOException {
-    checkConnected(false);
-    if (!(addr instanceof InetSocketAddress)) {
-      throw new IllegalArgumentException(
-          "connect() requires an InetSocketAddress or a ScionSocketAddress.");
-    }
-    return connect(pathPolicy.filter(getService().getPaths((InetSocketAddress) addr)));
-  }
-
-  /**
-   * Connect to a destination host. Note: - A SCION channel will internally connect to the next
-   * border router (first hop) instead of the remote host. - The path will be replaced with a new
-   * path once it is expired.
-   *
-   * <p>NB: This method does internally no call {@link java.nio.channels.DatagramChannel}.connect(),
-   * instead it calls bind(). That means this method does NOT perform any additional security checks
-   * associated with connect(), only those associated with bind().
-   *
-   * @param path Path to the remote host.
-   * @return This channel.
-   * @throws IOException for example when the first hop (border router) cannot be connected.
-   */
-  public synchronized DatagramChannel connect(RequestPath path) throws IOException {
-    checkConnected(false);
-    this.path = path;
-    isConnected = true;
-    connection = path.getFirstHopAddress();
-    channel.connect(connection);
-    return this;
-  }
-
-  /**
-   * Get the currently connected path.
-   *
-   * @return the current Path or `null` if not path is connected.
-   */
-  public synchronized Path getCurrentPath() {
-    return path;
+    return super.isBlocking();
   }
 
   public synchronized ResponsePath receive(ByteBuffer userBuffer) throws IOException {
-    ResponsePath receivePath = receiveFromChannel(InternalConstants.HdrTypes.UDP);
+    ResponsePath receivePath = receiveFromChannel(bufferReceive, InternalConstants.HdrTypes.UDP);
     if (receivePath == null) {
       return null; // non-blocking, nothing available
     }
-    ScionHeaderParser.extractUserPayload(buffer, userBuffer);
-    buffer.clear();
+    ScionHeaderParser.extractUserPayload(bufferReceive, userBuffer);
+    bufferReceive.clear();
     return receivePath;
-  }
-
-  synchronized Scmp.Message receiveScmp() throws IOException {
-    ResponsePath receivePath = receiveFromChannel(InternalConstants.HdrTypes.SCMP);
-    if (receivePath == null) {
-      return null; // non-blocking, nothing available
-    }
-    return receiveScmp(receivePath);
-  }
-
-  synchronized Scmp.Message receiveScmp(Scmp.Message msg) throws IOException {
-    ResponsePath receivePath = receiveFromChannel(InternalConstants.HdrTypes.SCMP);
-    if (receivePath == null) {
-      return null; // non-blocking, nothing available
-    }
-    msg.setPath(receivePath);
-    return receiveScmpInternal(msg);
-  }
-
-  private ResponsePath receiveFromChannel(InternalConstants.HdrTypes expectedHdrType)
-      throws IOException {
-    while (true) {
-      buffer.clear();
-      InetSocketAddress srcAddress = (InetSocketAddress) channel.receive(buffer);
-      if (srcAddress == null) {
-        // this indicates nothing is available - non-blocking mode
-        return null;
-      }
-      buffer.flip();
-
-      String validationResult = ScionHeaderParser.validate(buffer.asReadOnlyBuffer());
-      if (validationResult != null) {
-        if (cfgReportFailedValidation) {
-          throw new ScionException(validationResult);
-        }
-        continue;
-      }
-
-      InternalConstants.HdrTypes hdrType = ScionHeaderParser.extractNextHeader(buffer);
-      if (expectedHdrType == hdrType && hdrType == InternalConstants.HdrTypes.UDP) {
-        return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
-      }
-
-      // From here on we use linear reading using the buffer's position() mechanism
-      buffer.position(ScionHeaderParser.extractHeaderLength(buffer));
-      if (hdrType == InternalConstants.HdrTypes.END_TO_END
-          || hdrType == InternalConstants.HdrTypes.HOP_BY_HOP) {
-        ExtensionHeader extHdr = ExtensionHeader.consume(buffer);
-        // Currently we are not doing much here except hoping for an SCMP header
-        hdrType = extHdr.nextHdr();
-        if (hdrType != InternalConstants.HdrTypes.SCMP) {
-          throw new UnsupportedOperationException("Extension header not supported: " + hdrType);
-        }
-      }
-
-      if (hdrType == expectedHdrType) {
-        return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
-      }
-      receiveScmp(path);
-    }
-  }
-
-  private Object receiveNonDataPacket(InternalConstants.HdrTypes hdrType, ResponsePath path)
-      throws ScionException {
-    switch (hdrType) {
-      case HOP_BY_HOP:
-      case END_TO_END:
-        return receiveExtension(path);
-        // break;
-      case SCMP:
-        return receiveScmp(path);
-        // break;
-      default:
-        if (cfgReportFailedValidation) {
-          throw new ScionException("Unknown nextHdr: " + hdrType);
-        }
-    }
-    return null;
-  }
-
-  private Object receiveExtension(ResponsePath path) throws ScionException {
-    ExtensionHeader extHdr = ExtensionHeader.consume(buffer);
-    // Currently we are not doing much here except hoping for an SCMP header
-    return receiveNonDataPacket(extHdr.nextHdr(), path);
-  }
-
-  private Scmp.Message receiveScmp(Path path) {
-    Scmp.Message scmpMsg = ScmpParser.consume(buffer, path);
-    if (scmpMsg instanceof Scmp.EchoResult) {
-      if (pingListener != null) {
-        pingListener.accept((Scmp.EchoResult) scmpMsg);
-      }
-    } else if (scmpMsg instanceof Scmp.TracerouteResult) {
-      if (traceListener != null) {
-        traceListener.accept((Scmp.TracerouteResult) scmpMsg);
-      }
-    } else {
-      if (errorListener != null) {
-        errorListener.accept(scmpMsg);
-      }
-    }
-    return scmpMsg;
-  }
-
-  private Scmp.Message receiveScmpInternal(Scmp.Message holder) {
-    Scmp.Message scmpMsg = ScmpParser.consume(buffer, holder);
-    if (scmpMsg instanceof Scmp.EchoResult) {
-      if (pingListener != null) {
-        pingListener.accept((Scmp.EchoResult) scmpMsg);
-      }
-    } else if (scmpMsg instanceof Scmp.TracerouteResult) {
-      if (traceListener != null) {
-        traceListener.accept((Scmp.TracerouteResult) scmpMsg);
-      }
-    } else {
-      if (errorListener != null) {
-        errorListener.accept(scmpMsg);
-      }
-    }
-    return scmpMsg;
   }
 
   /**
@@ -342,7 +85,7 @@ public class DatagramChannel implements ByteChannel, Closeable {
     if (!(destination instanceof InetSocketAddress)) {
       throw new IllegalArgumentException("Address must be of type InetSocketAddress.");
     }
-    send(srcBuffer, pathPolicy.filter(getService().getPaths((InetSocketAddress) destination)));
+    send(srcBuffer, getPathPolicy().filter(getService().getPaths((InetSocketAddress) destination)));
   }
 
   /**
@@ -359,73 +102,12 @@ public class DatagramChannel implements ByteChannel, Closeable {
    */
   public synchronized Path send(ByteBuffer srcBuffer, Path path) throws IOException {
     // + 8 for UDP overlay header length
-    Path actualPath = buildHeader(path, srcBuffer.remaining() + 8, InternalConstants.HdrTypes.UDP);
-    buffer.put(srcBuffer);
-    buffer.flip();
-    channel.send(buffer, actualPath.getFirstHopAddress());
+    Path actualPath =
+        buildHeader(bufferSend, path, srcBuffer.remaining() + 8, InternalConstants.HdrTypes.UDP);
+    bufferSend.put(srcBuffer);
+    bufferSend.flip();
+    sendRaw(bufferSend, actualPath.getFirstHopAddress());
     return actualPath;
-  }
-
-  public synchronized void sendEchoRequest(Path path, int sequenceNumber, ByteBuffer data)
-      throws IOException {
-    // EchoHeader = 8 + data
-    int len = 8 + data.remaining();
-    Path actualPath = buildHeader(path, len, InternalConstants.HdrTypes.SCMP);
-    ScmpParser.buildScmpPing(buffer, getLocalAddress().getPort(), sequenceNumber, data);
-    buffer.flip();
-    channel.send(buffer, actualPath.getFirstHopAddress());
-  }
-
-  public synchronized Scmp.EchoResult sendEchoRequest(Scmp.EchoResult request) throws IOException {
-    // EchoHeader = 8 + data
-    int len = 8 + request.getData().length;
-    Path actualPath = buildHeader(path, len, InternalConstants.HdrTypes.SCMP);
-    request.setPath(actualPath);
-    ScmpParser.buildScmpPing(
-        buffer, getLocalAddress().getPort(), request.getSequenceNumber(), request.getData());
-    buffer.flip();
-    channel.send(buffer, actualPath.getFirstHopAddress());
-    return request;
-  }
-
-  void sendTracerouteRequest(Path path, int interfaceNumber, PathHeaderParser.Node node)
-      throws IOException {
-    // TracerouteHeader = 24
-    int len = 24;
-    // TODO we are modifying the raw path here, this is bad! It breaks concurrent usage.
-    //   we should only modify the outgoing packet.
-    byte[] raw = path.getRawPath();
-    raw[node.posHopFlags] = node.hopFlags;
-    Path actualPath = buildHeader(path, len, InternalConstants.HdrTypes.SCMP);
-    ScmpParser.buildScmpTraceroute(buffer, getLocalAddress().getPort(), interfaceNumber);
-    buffer.flip();
-    channel.send(buffer, actualPath.getFirstHopAddress());
-    // Clean up!  // TODO this is really bad!
-    raw[node.posHopFlags] = 0;
-  }
-
-  void sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {
-    channel.send(buffer, address);
-  }
-
-  public synchronized Consumer<Scmp.EchoResult> setEchoListener(
-      Consumer<Scmp.EchoResult> listener) {
-    Consumer<Scmp.EchoResult> old = pingListener;
-    pingListener = listener;
-    return old;
-  }
-
-  public synchronized Consumer<Scmp.TracerouteResult> setTracerouteListener(
-      Consumer<Scmp.TracerouteResult> listener) {
-    Consumer<Scmp.TracerouteResult> old = traceListener;
-    traceListener = listener;
-    return old;
-  }
-
-  public synchronized Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {
-    Consumer<Scmp.Message> old = errorListener;
-    errorListener = listener;
-    return old;
   }
 
   /**
@@ -468,133 +150,14 @@ public class DatagramChannel implements ByteChannel, Closeable {
 
     int len = src.remaining();
     // + 8 for UDP overlay header length
-    buildHeader(path, len + 8, InternalConstants.HdrTypes.UDP);
-    buffer.put(src);
-    buffer.flip();
+    buildHeader(bufferSend, getCurrentPath(), len + 8, InternalConstants.HdrTypes.UDP);
+    bufferSend.put(src);
+    bufferSend.flip();
 
-    int sent = channel.write(buffer);
-    if (sent < buffer.limit() || buffer.remaining() > 0) {
+    int sent = channel().write(bufferSend);
+    if (sent < bufferSend.limit() || bufferSend.remaining() > 0) {
       throw new ScionException("Failed to send all data.");
     }
-    return len - buffer.remaining();
-  }
-
-  private void checkOpen() throws ClosedChannelException {
-    if (!channel.isOpen()) {
-      throw new ClosedChannelException();
-    }
-  }
-
-  private void checkConnected(boolean requiredState) {
-    if (requiredState != isConnected) {
-      if (isConnected) {
-        throw new AlreadyConnectedException();
-      } else {
-        throw new NotYetConnectedException();
-      }
-    }
-  }
-
-  public synchronized boolean isConnected() {
-    return isConnected;
-  }
-
-  public synchronized <T> DatagramChannel setOption(SocketOption<T> option, T t)
-      throws IOException {
-    if (option instanceof ScionSocketOptions.SciSocketOption) {
-      if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
-        cfgReportFailedValidation = (Boolean) t;
-      } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
-        cfgExpirationSafetyMargin = (Integer) t;
-      } else if (StandardSocketOptions.SO_RCVBUF.equals(option)) {
-        // TODO resize buf
-        channel.setOption(option, t);
-      } else if (StandardSocketOptions.SO_SNDBUF.equals(option)) {
-        // TODO resize buf
-        channel.setOption(option, t);
-      } else {
-        throw new UnsupportedOperationException();
-      }
-    } else {
-      channel.setOption(option, t);
-    }
-    return this;
-  }
-
-  /**
-   * @param path path
-   * @param payloadLength payload length
-   * @return argument path or a new path if the argument path was expired
-   * @throws IOException in case of IOException.
-   */
-  Path buildHeader(Path path, int payloadLength, InternalConstants.HdrTypes hdrType)
-      throws IOException {
-    buffer.clear();
-    long srcIA;
-    byte[] srcAddress;
-    int srcPort;
-    if (path instanceof ResponsePath) {
-      // We could get source IA, address and port locally, but it seems cleaner
-      // to get these from the inverted header.
-      ResponsePath rPath = (ResponsePath) path;
-      srcIA = rPath.getSourceIsdAs();
-      srcAddress = rPath.getSourceAddress();
-      srcPort = rPath.getSourcePort();
-    } else {
-      // For sending request path we need to have a valid local external address.
-      // For a valid local external address we need to be connected.
-      if (!isConnected) {
-        isConnected = true;
-        connection = path.getFirstHopAddress();
-        channel.connect(connection);
-      }
-
-      // check path expiration
-      path = ensureUpToDate((RequestPath) path);
-      srcIA = getService().getLocalIsdAs();
-      // Get external host address. This must be done *after* refreshing the path!
-      InetSocketAddress srcSocketAddress = (InetSocketAddress) channel.getLocalAddress();
-      srcAddress = srcSocketAddress.getAddress().getAddress();
-      srcPort = srcSocketAddress.getPort();
-    }
-
-    long dstIA = path.getDestinationIsdAs();
-    byte[] dstAddress = path.getDestinationAddress();
-    int dstPort = path.getDestinationPort();
-
-    byte[] rawPath = path.getRawPath();
-    ScionHeaderParser.write(
-        buffer, payloadLength, rawPath.length, srcIA, srcAddress, dstIA, dstAddress, hdrType);
-    ScionHeaderParser.writePath(buffer, rawPath);
-
-    // TODO move this outside of this method
-    if (hdrType == InternalConstants.HdrTypes.UDP) {
-      ScionHeaderParser.writeUdpOverlayHeader(buffer, payloadLength, srcPort, dstPort);
-    }
-
-    return path;
-  }
-
-  private Path ensureUpToDate(RequestPath path) throws IOException {
-    if (Instant.now().getEpochSecond() + cfgExpirationSafetyMargin <= path.getExpiration()) {
-      return path;
-    }
-    return updatePath(path);
-  }
-
-  private Path updatePath(RequestPath path) throws IOException {
-    // expired, get new path
-    RequestPath newPath = pathPolicy.filter(getService().getPaths(path));
-
-    if (isConnected) { // equal to !isBound at this point
-      if (!newPath.getFirstHopAddress().equals(this.connection)) {
-        // TODO only reconnect if firstHop is on different interface....?!
-        channel.disconnect();
-        this.connection = newPath.getFirstHopAddress();
-        channel.connect(this.connection);
-      }
-      this.path = newPath;
-    }
-    return newPath;
+    return len - bufferSend.remaining();
   }
 }

--- a/src/main/java/org/scion/Scmp.java
+++ b/src/main/java/org/scion/Scmp.java
@@ -166,6 +166,10 @@ public class Scmp {
       return text;
     }
 
+    public boolean isError() {
+      return type >= ScmpType.ERROR_1.id && type <= ScmpType.ERROR_127.id;
+    }
+
     @Override
     public String toString() {
       return type + ":" + id + ":'" + text + '\'';
@@ -216,8 +220,10 @@ public class Scmp {
   public static class EchoResult extends Message {
     private final byte[] data;
     private long nanoSeconds;
+    private boolean timedOut = false;
 
     /** DO NOT USE! */
+    @Deprecated
     public EchoResult(
         ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path, byte[] data) {
       super(typeCode, identifier, sequenceNumber, path);
@@ -228,12 +234,6 @@ public class Scmp {
       byte[] data = new byte[payload.remaining()];
       payload.get(data);
       return new EchoResult(ScmpTypeCode.TYPE_128, -1, sequenceNumber, path, data);
-    }
-
-    public static EchoResult createTimedOut(long nanoSeconds) {
-      EchoResult r = new EchoResult(null, -1, -1, null, null);
-      r.setNanoSeconds(nanoSeconds);
-      return r;
     }
 
     public byte[] getData() {
@@ -247,6 +247,15 @@ public class Scmp {
     public long getNanoSeconds() {
       return nanoSeconds;
     }
+
+    public void setTimedOut(long nanoSeconds) {
+      this.nanoSeconds = nanoSeconds;
+      this.timedOut = true;
+    }
+
+    public boolean isTimedOut() {
+      return timedOut;
+    }
   }
 
   public static class TracerouteResult extends Message {
@@ -254,10 +263,15 @@ public class Scmp {
     private long isdAs;
     private long ifID;
     private long nanoSeconds;
+    private boolean timedOut = false;
 
     /** DO NOT USE! */
     public TracerouteResult(ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
       this(typeCode, identifier, sequenceNumber, 0, 0, path);
+    }
+
+    public static TracerouteResult createRequest(int sequenceNumber, Path path) {
+      return new TracerouteResult(ScmpTypeCode.TYPE_130, -1, sequenceNumber, path);
     }
 
     public static TracerouteResult createTimedOut(long nanoSeconds) {
@@ -305,6 +319,15 @@ public class Scmp {
     public void setTracerouteArgs(long isdAs, long ifID) {
       this.isdAs = isdAs;
       this.ifID = ifID;
+    }
+
+    public void setTimedOut(long nanoSeconds) {
+      this.nanoSeconds = nanoSeconds;
+      this.timedOut = true;
+    }
+
+    public boolean isTimedOut() {
+      return timedOut;
     }
   }
 

--- a/src/main/java/org/scion/Scmp.java
+++ b/src/main/java/org/scion/Scmp.java
@@ -217,23 +217,23 @@ public class Scmp {
     }
   }
 
-  public static class EchoResult extends Message {
+  public static class EchoPacket extends Message {
     private final byte[] data;
     private long nanoSeconds;
     private boolean timedOut = false;
 
     /** DO NOT USE! */
     @Deprecated
-    public EchoResult(
+    public EchoPacket(
         ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path, byte[] data) {
       super(typeCode, identifier, sequenceNumber, path);
       this.data = data;
     }
 
-    public static EchoResult createRequest(int sequenceNumber, Path path, ByteBuffer payload) {
+    public static EchoPacket createRequest(int sequenceNumber, Path path, ByteBuffer payload) {
       byte[] data = new byte[payload.remaining()];
       payload.get(data);
-      return new EchoResult(ScmpTypeCode.TYPE_128, -1, sequenceNumber, path, data);
+      return new EchoPacket(ScmpTypeCode.TYPE_128, -1, sequenceNumber, path, data);
     }
 
     public byte[] getData() {
@@ -258,7 +258,7 @@ public class Scmp {
     }
   }
 
-  public static class TracerouteResult extends Message {
+  public static class TraceroutePacket extends Message {
 
     private long isdAs;
     private long ifID;
@@ -266,21 +266,21 @@ public class Scmp {
     private boolean timedOut = false;
 
     /** DO NOT USE! */
-    public TracerouteResult(ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
+    public TraceroutePacket(ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
       this(typeCode, identifier, sequenceNumber, 0, 0, path);
     }
 
-    public static TracerouteResult createRequest(int sequenceNumber, Path path) {
-      return new TracerouteResult(ScmpTypeCode.TYPE_130, -1, sequenceNumber, path);
+    public static TraceroutePacket createRequest(int sequenceNumber, Path path) {
+      return new TraceroutePacket(ScmpTypeCode.TYPE_130, -1, sequenceNumber, path);
     }
 
-    public static TracerouteResult createTimedOut(long nanoSeconds) {
-      TracerouteResult r = new TracerouteResult(null, -1, -1, null);
+    public static TraceroutePacket createTimedOut(long nanoSeconds) {
+      TraceroutePacket r = new TraceroutePacket(null, -1, -1, null);
       r.setNanoSeconds(nanoSeconds);
       return r;
     }
 
-    public TracerouteResult(
+    public TraceroutePacket(
         ScmpTypeCode typeCode,
         int identifier,
         int sequenceNumber,

--- a/src/main/java/org/scion/Scmp.java
+++ b/src/main/java/org/scion/Scmp.java
@@ -217,23 +217,27 @@ public class Scmp {
     }
   }
 
-  public static class EchoPacket extends Message {
+  public static class EchoMessage extends Message {
     private final byte[] data;
     private long nanoSeconds;
     private boolean timedOut = false;
 
     /** DO NOT USE! */
     @Deprecated
-    public EchoPacket(
+    public EchoMessage(
         ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path, byte[] data) {
       super(typeCode, identifier, sequenceNumber, path);
       this.data = data;
     }
 
-    public static EchoPacket createRequest(int sequenceNumber, Path path, ByteBuffer payload) {
+    public static EchoMessage createEmpty(Path path) {
+      return new EchoMessage(ScmpTypeCode.TYPE_128, -1, -1, path, null);
+    }
+
+    public static EchoMessage createRequest(int sequenceNumber, Path path, ByteBuffer payload) {
       byte[] data = new byte[payload.remaining()];
       payload.get(data);
-      return new EchoPacket(ScmpTypeCode.TYPE_128, -1, sequenceNumber, path, data);
+      return new EchoMessage(ScmpTypeCode.TYPE_128, -1, sequenceNumber, path, data);
     }
 
     public byte[] getData() {
@@ -258,7 +262,7 @@ public class Scmp {
     }
   }
 
-  public static class TraceroutePacket extends Message {
+  public static class TracerouteMessage extends Message {
 
     private long isdAs;
     private long ifID;
@@ -266,21 +270,25 @@ public class Scmp {
     private boolean timedOut = false;
 
     /** DO NOT USE! */
-    public TraceroutePacket(ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
+    public TracerouteMessage(ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
       this(typeCode, identifier, sequenceNumber, 0, 0, path);
     }
 
-    public static TraceroutePacket createRequest(int sequenceNumber, Path path) {
-      return new TraceroutePacket(ScmpTypeCode.TYPE_130, -1, sequenceNumber, path);
+    public static TracerouteMessage createEmpty(Path path) {
+      return new TracerouteMessage(ScmpTypeCode.TYPE_130, -1, -1, path);
     }
 
-    public static TraceroutePacket createTimedOut(long nanoSeconds) {
-      TraceroutePacket r = new TraceroutePacket(null, -1, -1, null);
+    public static TracerouteMessage createRequest(int sequenceNumber, Path path) {
+      return new TracerouteMessage(ScmpTypeCode.TYPE_130, -1, sequenceNumber, path);
+    }
+
+    public static TracerouteMessage createTimedOut(long nanoSeconds) {
+      TracerouteMessage r = new TracerouteMessage(null, -1, -1, null);
       r.setNanoSeconds(nanoSeconds);
       return r;
     }
 
-    public TraceroutePacket(
+    public TracerouteMessage(
         ScmpTypeCode typeCode,
         int identifier,
         int sequenceNumber,

--- a/src/main/java/org/scion/Scmp.java
+++ b/src/main/java/org/scion/Scmp.java
@@ -218,13 +218,11 @@ public class Scmp {
   }
 
   public static class EchoMessage extends Message {
-    private final byte[] data;
+    private byte[] data;
     private long nanoSeconds;
     private boolean timedOut = false;
 
-    /** DO NOT USE! */
-    @Deprecated
-    public EchoMessage(
+    private EchoMessage(
         ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path, byte[] data) {
       super(typeCode, identifier, sequenceNumber, path);
       this.data = data;
@@ -242,6 +240,10 @@ public class Scmp {
 
     public byte[] getData() {
       return data;
+    }
+
+    public void setData(byte[] data) {
+      this.data = data;
     }
 
     public void setNanoSeconds(long nanoSeconds) {
@@ -269,8 +271,8 @@ public class Scmp {
     private long nanoSeconds;
     private boolean timedOut = false;
 
-    /** DO NOT USE! */
-    public TracerouteMessage(ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
+    private TracerouteMessage(
+        ScmpTypeCode typeCode, int identifier, int sequenceNumber, Path path) {
       this(typeCode, identifier, sequenceNumber, 0, 0, path);
     }
 
@@ -336,6 +338,19 @@ public class Scmp {
 
     public boolean isTimedOut() {
       return timedOut;
+    }
+  }
+
+  static Scmp.Message createMessage(Scmp.ScmpType type, Path path) {
+    switch (type) {
+      case INFO_128:
+      case INFO_129:
+        return Scmp.EchoMessage.createEmpty(path);
+      case INFO_130:
+      case INFO_131:
+        return Scmp.TracerouteMessage.createEmpty(path);
+      default:
+        return new Scmp.Message(null, -1, -1, path);
     }
   }
 

--- a/src/main/java/org/scion/ScmpChannel.java
+++ b/src/main/java/org/scion/ScmpChannel.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 import org.scion.internal.PathHeaderParser;
 
 public class ScmpChannel implements AutoCloseable {
-  private final DatagramChannel channel;
+  private final ScmpDatagramChannel channel;
   private final RequestPath path;
   private final AtomicReference<Scmp.Message> error = new AtomicReference<>();
   private int timeOutMs = 1000;
@@ -39,8 +39,7 @@ public class ScmpChannel implements AutoCloseable {
     this.path = path;
     InetSocketAddress local = new InetSocketAddress("0.0.0.0", port);
     ScionService service = Scion.defaultService();
-    this.channel = service.openChannel().bind(local);
-    channel.configureBlocking(true);
+    this.channel = ScmpDatagramChannel.open(service).bind(local);
     channel.setScmpErrorListener(this::errorListener);
   }
 

--- a/src/main/java/org/scion/ScmpChannel.java
+++ b/src/main/java/org/scion/ScmpChannel.java
@@ -16,18 +16,19 @@ package org.scion;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketOption;
+import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
+import org.scion.internal.InternalConstants;
 import org.scion.internal.PathHeaderParser;
+import org.scion.internal.ScmpParser;
 
-public class ScmpChannel implements AutoCloseable {
-  private final ScmpDatagramChannel channel;
-  private final RequestPath path;
+public class ScmpChannel extends AbstractDatagramChannel<ScmpChannel> implements AutoCloseable {
+  private final ByteBuffer bufferReceive;
+  private final ByteBuffer bufferSend;
   private final AtomicReference<Scmp.Message> error = new AtomicReference<>();
   private int timeOutMs = 1000;
 
@@ -36,10 +37,70 @@ public class ScmpChannel implements AutoCloseable {
   }
 
   ScmpChannel(RequestPath path, int port) throws IOException {
-    this.path = path;
+    super(Scion.defaultService());
+    configureBlocking(true);
+    this.bufferReceive = ByteBuffer.allocateDirect(getOption(StandardSocketOptions.SO_RCVBUF));
+    this.bufferSend = ByteBuffer.allocateDirect(getOption(StandardSocketOptions.SO_SNDBUF));
+
+    setPath(path);
     InetSocketAddress local = new InetSocketAddress("0.0.0.0", port);
-    ScionService service = Scion.defaultService();
-    this.channel = ScmpDatagramChannel.open(service).bind(local);
+    this.bind(local);
+  }
+
+  private synchronized Scmp.EchoResult sendEchoRequest(Scmp.EchoResult request) throws IOException {
+    // send
+    // EchoHeader = 8 + data
+    int len = 8 + request.getData().length;
+    Path path = request.getPath();
+    buildHeaderNoRefresh(bufferSend, request.getPath(), len, InternalConstants.HdrTypes.SCMP);
+    ScmpParser.buildScmpPing(
+        bufferSend, getLocalAddress().getPort(), request.getSequenceNumber(), request.getData());
+    bufferSend.flip();
+    sendRaw(bufferSend, path.getFirstHopAddress());
+
+    // receive
+    Scmp.Message scmpMsg = null;
+    ResponsePath receivePath = null;
+    while (scmpMsg == null) {
+      receivePath = receiveFromChannel(bufferReceive, InternalConstants.HdrTypes.SCMP);
+      scmpMsg = ScmpParser.consume(bufferReceive, request);
+    }
+    scmpMsg.setPath(receivePath);
+    checkListeners(scmpMsg);
+    return (Scmp.EchoResult) scmpMsg;
+  }
+
+  private Scmp.TracerouteResult sendTracerouteRequest(
+      Scmp.TracerouteResult request, PathHeaderParser.Node node) throws IOException {
+    Path path = request.getPath();
+    // send
+    // TracerouteHeader = 24
+    int len = 24;
+    // TODO we are modifying the raw path here, this is bad! It breaks concurrent usage.
+    //   we should only modify the outgoing packet.
+    byte[] raw = path.getRawPath();
+    byte backup = raw[node.posHopFlags];
+    raw[node.posHopFlags] = node.hopFlags;
+
+    buildHeaderNoRefresh(bufferSend, path, len, InternalConstants.HdrTypes.SCMP);
+    int interfaceNumber = request.getSequenceNumber();
+    ScmpParser.buildScmpTraceroute(bufferSend, getLocalAddress().getPort(), interfaceNumber);
+    bufferSend.flip();
+    sendRaw(bufferSend, path.getFirstHopAddress());
+    // Clean up!  // TODO this is really bad!
+    raw[node.posHopFlags] = backup;
+
+    // receive
+    Scmp.Message scmpMsg = null;
+    ResponsePath receivePath = null;
+    while (scmpMsg == null) {
+      receivePath = receiveFromChannel(bufferReceive, InternalConstants.HdrTypes.SCMP);
+      scmpMsg = ScmpParser.consume(bufferReceive, request);
+    }
+
+    scmpMsg.setPath(receivePath);
+    checkListeners(scmpMsg);
+    return (Scmp.TracerouteResult) scmpMsg;
   }
 
   /**
@@ -53,8 +114,9 @@ public class ScmpChannel implements AutoCloseable {
    * @throws IOException if an IO error occurs or if an SCMP error is received.
    */
   public Scmp.EchoResult sendEchoRequest(int sequenceNumber, ByteBuffer data) throws IOException {
-    if (!channel.isConnected()) {
-      channel.connect(path);
+    RequestPath path = (RequestPath) getCurrentPath();
+    if (!isConnected()) {
+      connect(path);
     }
     // Hack: we do not modify the AtomicReference.It simply serves as a memory barrier
     // to facilitate concurrent access to the result.
@@ -92,7 +154,7 @@ public class ScmpChannel implements AutoCloseable {
       AtomicReference<Scmp.EchoResult> result, AtomicReference<IOException> exception) {
     try {
       long sendNanos = System.nanoTime();
-      Scmp.EchoResult msg = channel.sendEchoRequest(result.get());
+      Scmp.EchoResult msg = sendEchoRequest(result.get());
       long nanos = System.nanoTime() - sendNanos;
       if (msg.getTypeCode() == Scmp.ScmpTypeCode.TYPE_129) {
         msg.setNanoSeconds(nanos);
@@ -116,28 +178,27 @@ public class ScmpChannel implements AutoCloseable {
    */
   public Collection<Scmp.TracerouteResult> sendTracerouteRequest() throws IOException {
     ConcurrentLinkedQueue<Scmp.TracerouteResult> results = new ConcurrentLinkedQueue<>();
-    try {
-      List<PathHeaderParser.Node> nodes = PathHeaderParser.getTraceNodes(path.getRawPath());
-      for (int i = 0; i < nodes.size(); i++) {
-        if (!sendConcurrentTraceRequest(i, nodes.get(i), results)) {
-          // timeout: abort
-          break;
-        }
+    Path path = getCurrentPath();
+    List<PathHeaderParser.Node> nodes = PathHeaderParser.getTraceNodes(path.getRawPath());
+    for (int i = 0; i < nodes.size(); i++) {
+      if (!sendConcurrentTraceRequest(i, path, nodes.get(i), results)) {
+        // timeout: abort
+        break;
       }
-    } finally {
-      channel.setTracerouteListener(null);
     }
     return results;
   }
 
   private boolean sendConcurrentTraceRequest(
       int sequenceNumber,
+      Path path,
       PathHeaderParser.Node node,
       ConcurrentLinkedQueue<Scmp.TracerouteResult> results)
       throws IOException {
     AtomicReference<IOException> exception = new AtomicReference<>();
 
-    Thread t = new Thread(() -> sendTracerouteRequest(sequenceNumber, node, results, exception));
+    Thread t =
+        new Thread(() -> sendTracerouteRequest(path, sequenceNumber, node, results, exception));
     t.start();
     try {
       t.join(timeOutMs);
@@ -163,14 +224,15 @@ public class ScmpChannel implements AutoCloseable {
   }
 
   private void sendTracerouteRequest(
+      Path path,
       int sequenceNumber,
       PathHeaderParser.Node node,
       ConcurrentLinkedQueue<Scmp.TracerouteResult> results,
       AtomicReference<IOException> exception) {
     try {
-      long sendNanos = System.nanoTime();
       Scmp.TracerouteResult trace = Scmp.TracerouteResult.createRequest(sequenceNumber, path);
-      trace = channel.sendTracerouteRequest(trace, node);
+      long sendNanos = System.nanoTime();
+      trace = sendTracerouteRequest(trace, node);
       long nanos = System.nanoTime() - sendNanos;
       if (trace.getTypeCode() == Scmp.ScmpTypeCode.TYPE_131) {
         trace.setNanoSeconds(nanos);
@@ -184,21 +246,7 @@ public class ScmpChannel implements AutoCloseable {
     }
   }
 
-  public Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {
-    return channel.setScmpErrorListener(listener);
-  }
-
-  public synchronized <T> ScmpChannel setOption(SocketOption<T> option, T t) throws IOException {
-    channel.setOption(option, t);
-    return this;
-  }
-
   public void setTimeOut(int milliSeconds) {
     this.timeOutMs = milliSeconds;
-  }
-
-  @Override
-  public void close() throws IOException {
-    channel.close();
   }
 }

--- a/src/main/java/org/scion/ScmpChannel.java
+++ b/src/main/java/org/scion/ScmpChannel.java
@@ -40,13 +40,6 @@ public class ScmpChannel implements AutoCloseable {
     InetSocketAddress local = new InetSocketAddress("0.0.0.0", port);
     ScionService service = Scion.defaultService();
     this.channel = ScmpDatagramChannel.open(service).bind(local);
-    channel.setScmpErrorListener(this::errorListener);
-  }
-
-  private void errorListener(Scmp.Message msg) {
-    error.set(msg);
-    Thread.currentThread().interrupt();
-    throw new RuntimeException();
   }
 
   /**

--- a/src/main/java/org/scion/ScmpDatagramChannel.java
+++ b/src/main/java/org/scion/ScmpDatagramChannel.java
@@ -18,6 +18,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 import org.scion.internal.InternalConstants;
 import org.scion.internal.ScmpParser;
 
@@ -68,5 +69,10 @@ public class ScmpDatagramChannel extends AbstractDatagramChannel<ScmpDatagramCha
     Scmp.Message scmpMsg = ScmpParser.consume(bufferReceive, receivePath);
     checkListeners(scmpMsg);
     return scmpMsg;
+  }
+
+  public synchronized Consumer<Scmp.EchoMessage> setEchoListener(
+      Consumer<Scmp.EchoMessage> listener) {
+    return super.setEchoListener(listener);
   }
 }

--- a/src/main/java/org/scion/ScmpDatagramChannel.java
+++ b/src/main/java/org/scion/ScmpDatagramChannel.java
@@ -66,7 +66,8 @@ public class ScmpDatagramChannel extends AbstractDatagramChannel<ScmpDatagramCha
 
     // receive
     ResponsePath receivePath = receiveFromChannel(bufferReceive, InternalConstants.HdrTypes.SCMP);
-    Scmp.Message scmpMsg = ScmpParser.consume(bufferReceive, receivePath);
+    Scmp.Message scmpMsg =
+        ScmpParser.consume(bufferReceive, Scmp.EchoMessage.createEmpty(receivePath));
     checkListeners(scmpMsg);
     return scmpMsg;
   }

--- a/src/main/java/org/scion/ScmpDatagramChannel.java
+++ b/src/main/java/org/scion/ScmpDatagramChannel.java
@@ -1,0 +1,116 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.*;
+import java.nio.ByteBuffer;
+import org.scion.internal.InternalConstants;
+import org.scion.internal.PathHeaderParser;
+import org.scion.internal.ScmpParser;
+
+public class ScmpDatagramChannel extends AbstractDatagramChannel<ScmpDatagramChannel>
+    implements Closeable {
+
+  private final ByteBuffer buffer;
+
+  public static ScmpDatagramChannel open() throws IOException {
+    return new ScmpDatagramChannel();
+  }
+
+  public static ScmpDatagramChannel open(ScionService service) throws IOException {
+    return new ScmpDatagramChannel(service);
+  }
+
+  protected ScmpDatagramChannel() throws IOException {
+    this(null);
+  }
+
+  protected ScmpDatagramChannel(ScionService service) throws IOException {
+    super(service);
+    configureBlocking(true);
+    // TODO snd/rcv
+    int size =
+        Math.max(
+            getOption(StandardSocketOptions.SO_RCVBUF), getOption(StandardSocketOptions.SO_SNDBUF));
+    this.buffer = ByteBuffer.allocateDirect(size);
+  }
+
+  synchronized Scmp.Message receiveScmp() throws IOException {
+    ResponsePath receivePath = receiveFromChannel(buffer, InternalConstants.HdrTypes.SCMP);
+    if (receivePath == null) {
+      return null; // non-blocking, nothing available
+    }
+
+    Scmp.Message scmpMsg = ScmpParser.consume(buffer, receivePath);
+    checkListeners(scmpMsg);
+    return scmpMsg;
+  }
+
+  synchronized Scmp.Message receiveScmp(Scmp.Message msg) throws IOException {
+    ResponsePath receivePath = receiveFromChannel(buffer, InternalConstants.HdrTypes.SCMP);
+    if (receivePath == null) {
+      return null; // non-blocking, nothing available
+    }
+    msg.setPath(receivePath);
+    Scmp.Message scmpMsg = ScmpParser.consume(buffer, msg);
+    checkListeners(scmpMsg);
+    return scmpMsg;
+  }
+
+  @Deprecated // TODO REMOVE THIS
+  public synchronized void receive() throws IOException {
+    receiveFromChannel(buffer, InternalConstants.HdrTypes.UDP);
+  }
+
+  public synchronized void sendEchoRequest(Path path, int sequenceNumber, ByteBuffer data)
+      throws IOException {
+    // EchoHeader = 8 + data
+    int len = 8 + data.remaining();
+    Path actualPath = buildHeader(buffer, path, len, InternalConstants.HdrTypes.SCMP);
+    ScmpParser.buildScmpPing(buffer, getLocalAddress().getPort(), sequenceNumber, data);
+    buffer.flip();
+    sendRaw(buffer, actualPath.getFirstHopAddress());
+  }
+
+  public synchronized Scmp.EchoResult sendEchoRequest(Scmp.EchoResult request) throws IOException {
+    // EchoHeader = 8 + data
+    int len = 8 + request.getData().length;
+    Path actualPath = buildHeader(buffer, getCurrentPath(), len, InternalConstants.HdrTypes.SCMP);
+    request.setPath(actualPath);
+    ScmpParser.buildScmpPing(
+        buffer, getLocalAddress().getPort(), request.getSequenceNumber(), request.getData());
+    buffer.flip();
+    sendRaw(buffer, actualPath.getFirstHopAddress());
+    return request;
+  }
+
+  void sendTracerouteRequest(Path path, int interfaceNumber, PathHeaderParser.Node node)
+      throws IOException {
+    // TracerouteHeader = 24
+    int len = 24;
+    // TODO we are modifying the raw path here, this is bad! It breaks concurrent usage.
+    //   we should only modify the outgoing packet.
+    byte[] raw = path.getRawPath();
+    raw[node.posHopFlags] = node.hopFlags;
+    Path actualPath = buildHeader(buffer, path, len, InternalConstants.HdrTypes.SCMP);
+    ScmpParser.buildScmpTraceroute(buffer, getLocalAddress().getPort(), interfaceNumber);
+    buffer.flip();
+    sendRaw(buffer, actualPath.getFirstHopAddress());
+    // Clean up!  // TODO this is really bad!
+    raw[node.posHopFlags] = 0;
+  }
+}

--- a/src/main/java/org/scion/ScmpDatagramChannel.java
+++ b/src/main/java/org/scion/ScmpDatagramChannel.java
@@ -28,6 +28,7 @@ public class ScmpDatagramChannel extends AbstractDatagramChannel<ScmpDatagramCha
 
   private final ByteBuffer bufferReceive;
   private final ByteBuffer bufferSend;
+  private Consumer<Scmp.EchoMessage> echoListener;
 
   protected ScmpDatagramChannel() throws IOException {
     this(null);
@@ -69,11 +70,13 @@ public class ScmpDatagramChannel extends AbstractDatagramChannel<ScmpDatagramCha
     Scmp.Message scmpMsg =
         ScmpParser.consume(bufferReceive, Scmp.EchoMessage.createEmpty(receivePath));
     checkListeners(scmpMsg);
+    if (echoListener != null && scmpMsg instanceof Scmp.EchoMessage) {
+      echoListener.accept((Scmp.EchoMessage) scmpMsg);
+    }
     return scmpMsg;
   }
 
-  public synchronized Consumer<Scmp.EchoMessage> setEchoListener(
-      Consumer<Scmp.EchoMessage> listener) {
-    return super.setEchoListener(listener);
+  public synchronized void setEchoListener(Consumer<Scmp.EchoMessage> listener) {
+    echoListener = listener;
   }
 }

--- a/src/main/java/org/scion/internal/ScionBootstrapper.java
+++ b/src/main/java/org/scion/internal/ScionBootstrapper.java
@@ -51,13 +51,8 @@ public class ScionBootstrapper {
   private static final Logger LOG = LoggerFactory.getLogger(ScionBootstrapper.class.getName());
   private static final String STR_X_SCION = "x-sciondiscovery";
   private static final String STR_X_SCION_TCP = "x-sciondiscovery:tcp";
-  private static final String baseURL = "";
-  private static final String topologyEndpoint = "topology";
-  private static final String signedTopologyEndpoint = "topology.signed";
-  private static final String trcsEndpoint = "trcs";
-  private static final String trcBlobEndpoint = "trcs/isd%d-b%d-s%d/blob";
-  private static final String topologyJSONFileName = "topology.json";
-  private static final String signedTopologyFileName = "topology.signed";
+  private static final String BASE_URL = "";
+  private static final String TOPOLOGY_ENDPOINT = "topology";
   private static final Duration httpRequestTimeout = Duration.of(2, ChronoUnit.SECONDS);
   private final String topologyResource;
   private final List<ServiceNode> controlServices = new ArrayList<>();
@@ -181,7 +176,8 @@ public class ScionBootstrapper {
     try {
       parseTopologyFile(getTopologyFile());
     } catch (IOException e) {
-      throw new ScionRuntimeException("Error while getting topology file: " + e.getMessage(), e);
+      throw new ScionRuntimeException(
+          "Error while getting topology file from " + topologyResource + ": " + e.getMessage(), e);
     }
     if (controlServices.isEmpty()) {
       throw new ScionRuntimeException(
@@ -255,7 +251,7 @@ public class ScionBootstrapper {
     controlServices.clear();
     discoveryServices.clear();
     // TODO https????
-    URL url = new URL("http://" + topologyResource + "/" + baseURL + topologyEndpoint);
+    URL url = new URL("http://" + topologyResource + "/" + BASE_URL + TOPOLOGY_ENDPOINT);
     return fetchTopologyFile(url);
   }
 

--- a/src/main/java/org/scion/internal/ScmpParser.java
+++ b/src/main/java/org/scion/internal/ScmpParser.java
@@ -14,11 +14,11 @@
 
 package org.scion.internal;
 
-import static org.scion.Scmp.EchoResult;
+import static org.scion.Scmp.EchoPacket;
 import static org.scion.Scmp.Message;
 import static org.scion.Scmp.ScmpType;
 import static org.scion.Scmp.ScmpTypeCode;
-import static org.scion.Scmp.TracerouteResult;
+import static org.scion.Scmp.TraceroutePacket;
 
 import java.nio.ByteBuffer;
 import org.scion.Path;
@@ -99,13 +99,13 @@ public class ScmpParser {
       case INFO_129:
         byte[] scmpData = new byte[data.remaining()];
         data.get(scmpData);
-        return new EchoResult(sc, short1, short2, path, scmpData);
+        return new EchoPacket(sc, short1, short2, path, scmpData);
       case INFO_130:
-        return new TracerouteResult(sc, short1, short2, path);
+        return new TraceroutePacket(sc, short1, short2, path);
       case INFO_131:
         long isdAs = data.getLong();
         long ifID = data.getLong();
-        return new TracerouteResult(sc, short1, short2, isdAs, ifID, path);
+        return new TraceroutePacket(sc, short1, short2, isdAs, ifID, path);
       default:
         return new Message(sc, short1, short2, path);
     }
@@ -132,7 +132,7 @@ public class ScmpParser {
     switch (st) {
       case INFO_128:
       case INFO_129:
-        EchoResult echo = (EchoResult) holder;
+        EchoPacket echo = (EchoPacket) holder;
         if (data.remaining() != echo.getData().length) {
           // drop
           return null;
@@ -143,7 +143,7 @@ public class ScmpParser {
       case INFO_131:
         long isdAs = data.getLong();
         long ifID = data.getLong();
-        TracerouteResult trace = (TracerouteResult) holder;
+        TraceroutePacket trace = (TraceroutePacket) holder;
         trace.setTracerouteArgs(isdAs, ifID);
         return trace;
       default:

--- a/src/main/java/org/scion/internal/ScmpParser.java
+++ b/src/main/java/org/scion/internal/ScmpParser.java
@@ -14,11 +14,11 @@
 
 package org.scion.internal;
 
-import static org.scion.Scmp.ScmpEcho;
-import static org.scion.Scmp.ScmpMessage;
-import static org.scion.Scmp.ScmpTraceroute;
+import static org.scion.Scmp.EchoResult;
+import static org.scion.Scmp.Message;
 import static org.scion.Scmp.ScmpType;
 import static org.scion.Scmp.ScmpTypeCode;
+import static org.scion.Scmp.TracerouteResult;
 
 import java.nio.ByteBuffer;
 import org.scion.Path;
@@ -33,6 +33,16 @@ public class ScmpParser {
     buffer.put(ByteUtil.toByte(((len + 3) / 4) - 1));
     buffer.putShort((short) 0); // TODO this should be variable length!
     buffer.putInt(0);
+  }
+
+  public static void buildScmpPing(
+      ByteBuffer buffer, int identifier, int sequenceNumber, byte[] data) {
+    buffer.put(ByteUtil.toByte(ScmpType.INFO_128.id()));
+    buffer.put(ByteUtil.toByte(0));
+    buffer.putShort((short) 0); // TODO checksum
+    buffer.putShort((short) identifier); // unsigned
+    buffer.putShort((short) sequenceNumber); // unsigned
+    buffer.put(data);
   }
 
   public static void buildScmpPing(
@@ -73,7 +83,7 @@ public class ScmpParser {
    * @param path receive path
    * @return ScmpMessage object
    */
-  public static ScmpMessage consume(ByteBuffer data, Path path) {
+  public static Message consume(ByteBuffer data, Path path) {
     int type = ByteUtil.toUnsigned(data.get());
     int code = ByteUtil.toUnsigned(data.get());
     data.getShort(); // checksum
@@ -88,15 +98,55 @@ public class ScmpParser {
       case INFO_129:
         byte[] scmpData = new byte[data.remaining()];
         data.get(scmpData);
-        return new ScmpEcho(sc, short1, short2, path, scmpData);
+        return new EchoResult(sc, short1, short2, path, scmpData);
       case INFO_130:
-        return new ScmpTraceroute(sc, short1, short2, path);
+        return new TracerouteResult(sc, short1, short2, path);
       case INFO_131:
         long isdAs = data.getLong();
         long ifID = data.getLong();
-        return new ScmpTraceroute(sc, short1, short2, isdAs, ifID, path);
+        return new TracerouteResult(sc, short1, short2, isdAs, ifID, path);
       default:
-        return new ScmpMessage(sc, short1, short2, path);
+        return new Message(sc, short1, short2, path);
+    }
+  }
+
+  /**
+   * Reads a SCMP message from the packet. Consumes the byte buffer.
+   *
+   * @param data packet data
+   * @param holder SCMP message holder
+   * @return ScmpMessage object
+   */
+  public static Message consume(ByteBuffer data, Message holder) {
+    int type = ByteUtil.toUnsigned(data.get());
+    int code = ByteUtil.toUnsigned(data.get());
+    data.getShort(); // checksum
+    // TODO validate checksum
+
+    ScmpType st = ScmpType.parse(type);
+    ScmpTypeCode sc = ScmpTypeCode.parse(type, code);
+    int short1 = ByteUtil.toUnsigned(data.getShort());
+    int short2 = ByteUtil.toUnsigned(data.getShort());
+    holder.setMessageArgs(sc, short1, short2);
+    switch (st) {
+      case INFO_128:
+      case INFO_129:
+        EchoResult echo = (EchoResult) holder;
+        if (data.remaining() != echo.getData().length) {
+          // drop
+          return null;
+        }
+        data.get(echo.getData());
+        return echo;
+      case INFO_130:
+      case INFO_131:
+        long isdAs = data.getLong();
+        long ifID = data.getLong();
+        TracerouteResult trace = (TracerouteResult) holder;
+        trace.setTracerouteArgs(isdAs, ifID);
+        return trace;
+      default:
+        return holder;
     }
   }
 }

--- a/src/main/java/org/scion/internal/ScmpParser.java
+++ b/src/main/java/org/scion/internal/ScmpParser.java
@@ -83,6 +83,7 @@ public class ScmpParser {
    * @param path receive path
    * @return ScmpMessage object
    */
+  @Deprecated
   public static Message consume(ByteBuffer data, Path path) {
     int type = ByteUtil.toUnsigned(data.get());
     int code = ByteUtil.toUnsigned(data.get());

--- a/src/test/java/org/scion/PackageVisibilityHelper.java
+++ b/src/test/java/org/scion/PackageVisibilityHelper.java
@@ -44,6 +44,10 @@ public class PackageVisibilityHelper {
     return ScionHeaderParser.extractNextHeader(packet);
   }
 
+  public static Scmp.Message createMessage(Scmp.ScmpType type, Path path) {
+    return Scmp.createMessage(type, path);
+  }
+
   public static InetSocketAddress getDstAddress(ByteBuffer packet) throws UnknownHostException {
     return ScionHeaderParser.extractDestinationSocketAddress(packet);
   }

--- a/src/test/java/org/scion/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelApiTest.java
@@ -20,6 +20,7 @@ import com.google.protobuf.Timestamp;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.StandardSocketOptions;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -501,7 +502,7 @@ class DatagramChannelApiTest {
   }
 
   @Test
-  void geCurrentPath() {
+  void getCurrentPath() {
     RequestPath addr = ExamplePacket.PATH;
     ByteBuffer buffer = ByteBuffer.allocate(50);
     try (DatagramChannel channel = DatagramChannel.open()) {
@@ -518,6 +519,27 @@ class DatagramChannelApiTest {
       // TODO assertNull(channel.getCurrentPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void setOption() throws IOException {
+    try (DatagramChannel channel = DatagramChannel.open()) {
+      assertFalse(channel.getOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE));
+      DatagramChannel dc = channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
+      assertEquals(channel, dc);
+
+      int margin = channel.getOption(ScionSocketOptions.SN_PATH_EXPIRY_MARGIN);
+      channel.setOption(ScionSocketOptions.SN_PATH_EXPIRY_MARGIN, margin + 1000);
+      assertEquals(margin + 1000, channel.getOption(ScionSocketOptions.SN_PATH_EXPIRY_MARGIN));
+
+      int bufSizeSend = channel.getOption(StandardSocketOptions.SO_SNDBUF);
+      channel.setOption(StandardSocketOptions.SO_SNDBUF, bufSizeSend + 1000);
+      assertEquals(bufSizeSend + 1000, channel.getOption(StandardSocketOptions.SO_SNDBUF));
+
+      int bufSizeReceive = channel.getOption(StandardSocketOptions.SO_RCVBUF);
+      channel.setOption(StandardSocketOptions.SO_RCVBUF, bufSizeReceive + 1000);
+      assertEquals(bufSizeReceive + 1000, channel.getOption(StandardSocketOptions.SO_RCVBUF));
     }
   }
 }

--- a/src/test/java/org/scion/api/SCMPTest.java
+++ b/src/test/java/org/scion/api/SCMPTest.java
@@ -165,7 +165,7 @@ public class SCMPTest {
     try (ScmpChannel channel = Scmp.createChannel(getPathTo112())) {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
-      Collection<Scmp.TracerouteResult> results = channel.sendTracerouteRequestOld(); // TODO
+      Collection<Scmp.TracerouteResult> results = channel.sendTracerouteRequest();
       channel.setTimeOut(Integer.MAX_VALUE); // TODO ??
 
       int n = 0;
@@ -174,15 +174,13 @@ public class SCMPTest {
         assertEquals(Scmp.ScmpTypeCode.TYPE_131, result.getTypeCode());
         assertTrue(result.getNanoSeconds() > 0);
         assertTrue(result.getNanoSeconds() < 10_000_000); // 10 ms
-//        assertTrue(result.getIsdAs() != 0);
-//        assertTrue(result.getIfID() != 0);
         if (n == 1) {
-          assertEquals(ScionUtil.parseIA("1-ff00:0:110"), result.getIsdAs());
-          assertEquals(1, result.getIfID());
+          assertEquals(ScionUtil.parseIA("1-ff00:0:112"), result.getIsdAs());
+          assertEquals(42, result.getIfID());
         }
         if (n == 2) {
-          assertEquals(ScionUtil.parseIA("1-ff00:0:112"), result.getIsdAs());
-          assertEquals(2, result.getIfID());
+          assertEquals(ScionUtil.parseIA("1-ff00:0:110"), result.getIsdAs());
+          assertEquals(42, result.getIfID());
         }
       }
 

--- a/src/test/java/org/scion/api/SCMPTest.java
+++ b/src/test/java/org/scion/api/SCMPTest.java
@@ -99,7 +99,7 @@ public class SCMPTest {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       byte[] data = new byte[] {1, 2, 3, 4, 5};
-      Scmp.EchoPacket result = channel.sendEchoRequest(42, ByteBuffer.wrap(data));
+      Scmp.EchoMessage result = channel.sendEchoRequest(42, ByteBuffer.wrap(data));
       assertEquals(42, result.getSequenceNumber());
       assertEquals(Scmp.ScmpTypeCode.TYPE_129, result.getTypeCode());
       assertTrue(result.getNanoSeconds() > 0);
@@ -118,7 +118,7 @@ public class SCMPTest {
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       channel.setTimeOut(1_000);
       MockNetwork.dropNextPackets(1);
-      Scmp.EchoPacket result = channel.sendEchoRequest(42, ByteBuffer.allocate(0));
+      Scmp.EchoMessage result = channel.sendEchoRequest(42, ByteBuffer.allocate(0));
       assertTrue(result.isTimedOut());
       assertEquals(1_000 * 1_000_000, result.getNanoSeconds());
     } finally {
@@ -165,11 +165,11 @@ public class SCMPTest {
     try (ScmpChannel channel = Scmp.createChannel(getPathTo112())) {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
-      Collection<Scmp.TraceroutePacket> results = channel.sendTracerouteRequest();
+      Collection<Scmp.TracerouteMessage> results = channel.sendTracerouteRequest();
       channel.setTimeOut(Integer.MAX_VALUE); // TODO ??
 
       int n = 0;
-      for (Scmp.TraceroutePacket result : results) {
+      for (Scmp.TracerouteMessage result : results) {
         assertEquals(n++, result.getSequenceNumber());
         assertEquals(Scmp.ScmpTypeCode.TYPE_131, result.getTypeCode());
         assertTrue(result.getNanoSeconds() > 0);
@@ -197,10 +197,10 @@ public class SCMPTest {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       MockNetwork.dropNextPackets(2);
-      Collection<Scmp.TraceroutePacket> results = channel.sendTracerouteRequest();
+      Collection<Scmp.TracerouteMessage> results = channel.sendTracerouteRequest();
 
       assertEquals(1, results.size());
-      for (Scmp.TraceroutePacket result : results) {
+      for (Scmp.TracerouteMessage result : results) {
         assertNull(result.getTypeCode());
         assertEquals(1_000 * 1_000_000, result.getNanoSeconds());
       }

--- a/src/test/java/org/scion/api/SCMPTest.java
+++ b/src/test/java/org/scion/api/SCMPTest.java
@@ -99,7 +99,7 @@ public class SCMPTest {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       byte[] data = new byte[] {1, 2, 3, 4, 5};
-      Scmp.EchoResult result = channel.sendEchoRequest(42, ByteBuffer.wrap(data));
+      Scmp.EchoPacket result = channel.sendEchoRequest(42, ByteBuffer.wrap(data));
       assertEquals(42, result.getSequenceNumber());
       assertEquals(Scmp.ScmpTypeCode.TYPE_129, result.getTypeCode());
       assertTrue(result.getNanoSeconds() > 0);
@@ -118,7 +118,7 @@ public class SCMPTest {
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       channel.setTimeOut(1_000);
       MockNetwork.dropNextPackets(1);
-      Scmp.EchoResult result = channel.sendEchoRequest(42, ByteBuffer.allocate(0));
+      Scmp.EchoPacket result = channel.sendEchoRequest(42, ByteBuffer.allocate(0));
       assertTrue(result.isTimedOut());
       assertEquals(1_000 * 1_000_000, result.getNanoSeconds());
     } finally {
@@ -165,11 +165,11 @@ public class SCMPTest {
     try (ScmpChannel channel = Scmp.createChannel(getPathTo112())) {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
-      Collection<Scmp.TracerouteResult> results = channel.sendTracerouteRequest();
+      Collection<Scmp.TraceroutePacket> results = channel.sendTracerouteRequest();
       channel.setTimeOut(Integer.MAX_VALUE); // TODO ??
 
       int n = 0;
-      for (Scmp.TracerouteResult result : results) {
+      for (Scmp.TraceroutePacket result : results) {
         assertEquals(n++, result.getSequenceNumber());
         assertEquals(Scmp.ScmpTypeCode.TYPE_131, result.getTypeCode());
         assertTrue(result.getNanoSeconds() > 0);
@@ -197,10 +197,10 @@ public class SCMPTest {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       MockNetwork.dropNextPackets(2);
-      Collection<Scmp.TracerouteResult> results = channel.sendTracerouteRequest();
+      Collection<Scmp.TraceroutePacket> results = channel.sendTracerouteRequest();
 
       assertEquals(1, results.size());
-      for (Scmp.TracerouteResult result : results) {
+      for (Scmp.TraceroutePacket result : results) {
         assertNull(result.getTypeCode());
         assertEquals(1_000 * 1_000_000, result.getNanoSeconds());
       }

--- a/src/test/java/org/scion/api/SCMPTest.java
+++ b/src/test/java/org/scion/api/SCMPTest.java
@@ -99,12 +99,12 @@ public class SCMPTest {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       byte[] data = new byte[] {1, 2, 3, 4, 5};
-      Scmp.Result<Scmp.ScmpEcho> result = channel.sendEchoRequest(42, ByteBuffer.wrap(data));
-      assertEquals(42, result.getMessage().getSequenceNumber());
-      assertEquals(Scmp.ScmpTypeCode.TYPE_129, result.getMessage().getTypeCode());
+      Scmp.EchoResult result = channel.sendEchoRequest(42, ByteBuffer.wrap(data));
+      assertEquals(42, result.getSequenceNumber());
+      assertEquals(Scmp.ScmpTypeCode.TYPE_129, result.getTypeCode());
       assertTrue(result.getNanoSeconds() > 0);
       assertTrue(result.getNanoSeconds() < 10_000_000); // 10 ms
-      assertArrayEquals(data, result.getMessage().getData());
+      assertArrayEquals(data, result.getData());
     } finally {
       MockNetwork.stopTiny();
     }
@@ -118,8 +118,8 @@ public class SCMPTest {
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       channel.setTimeOut(1_000);
       MockNetwork.dropNextPackets(1);
-      Scmp.Result<Scmp.ScmpEcho> result = channel.sendEchoRequest(42, ByteBuffer.allocate(0));
-      assertNull(result.getMessage());
+      Scmp.EchoResult result = channel.sendEchoRequest(42, ByteBuffer.allocate(0));
+      assertNull(result.getTypeCode());
       assertEquals(1_000 * 1_000_000, result.getNanoSeconds());
     } finally {
       MockNetwork.stopTiny();
@@ -165,13 +165,13 @@ public class SCMPTest {
     try (ScmpChannel channel = Scmp.createChannel(getPathTo112())) {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
-      Collection<Scmp.Result<Scmp.ScmpTraceroute>> results = channel.sendTracerouteRequest();
+      Collection<Scmp.TracerouteResult> results = channel.sendTracerouteRequest();
       channel.setTimeOut(Integer.MAX_VALUE);
 
       int n = 0;
-      for (Scmp.Result<Scmp.ScmpTraceroute> result : results) {
-        assertEquals(n++, result.getMessage().getSequenceNumber());
-        assertEquals(Scmp.ScmpTypeCode.TYPE_131, result.getMessage().getTypeCode());
+      for (Scmp.TracerouteResult result : results) {
+        assertEquals(n++, result.getSequenceNumber());
+        assertEquals(Scmp.ScmpTypeCode.TYPE_131, result.getTypeCode());
         assertTrue(result.getNanoSeconds() > 0);
         assertTrue(result.getNanoSeconds() < 10_000_000); // 10 ms
       }
@@ -188,11 +188,11 @@ public class SCMPTest {
       channel.setScmpErrorListener(scmpMessage -> fail(scmpMessage.getTypeCode().getText()));
       channel.setOption(ScionSocketOptions.SN_API_THROW_PARSER_FAILURE, true);
       MockNetwork.dropNextPackets(2);
-      Collection<Scmp.Result<Scmp.ScmpTraceroute>> results = channel.sendTracerouteRequest();
+      Collection<Scmp.TracerouteResult> results = channel.sendTracerouteRequest();
 
       assertEquals(1, results.size());
-      for (Scmp.Result<Scmp.ScmpTraceroute> result : results) {
-        assertNull(result.getMessage());
+      for (Scmp.TracerouteResult result : results) {
+        assertNull(result.getTypeCode());
         assertEquals(1_000 * 1_000_000, result.getNanoSeconds());
       }
     } finally {

--- a/src/test/java/org/scion/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/demo/ScmpEchoDemo.java
@@ -31,7 +31,7 @@ public class ScmpEchoDemo {
   private final AtomicLong nowNanos = new AtomicLong();
   private final ByteBuffer sendBuffer = ByteBuffer.allocateDirect(8);
   private final int localPort;
-  private DatagramChannel channel;
+  private ScmpDatagramChannel channel;
   private Path path;
 
   private enum Network {
@@ -147,8 +147,7 @@ public class ScmpEchoDemo {
   private void doClientStuff(long destinationIA) throws IOException {
     InetSocketAddress local = new InetSocketAddress("0.0.0.0", localPort);
     ScionService service = Scion.defaultService();
-    try (DatagramChannel channel = service.openChannel().bind(local)) {
-      channel.configureBlocking(true);
+    try (ScmpDatagramChannel channel = ScmpDatagramChannel.open(service).bind(local)) {
       this.channel = channel;
 
       InetSocketAddress destinationAddress =
@@ -167,7 +166,7 @@ public class ScmpEchoDemo {
       send();
 
       println("Listening at " + channel.getLocalAddress() + " ...");
-      channel.receive(null);
+      channel.receive();
 
       channel.disconnect();
     }

--- a/src/test/java/org/scion/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/demo/ScmpEchoDemo.java
@@ -95,7 +95,7 @@ public class ScmpEchoDemo {
     }
   }
 
-  private void echoListener(Scmp.ScmpEcho msg) {
+  private void echoListener(Scmp.EchoResult msg) {
     String echoMsgStr = msg.getTypeCode().getText();
     echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();
     echoMsgStr += " time=" + getPassedMillies() + "ms";
@@ -103,7 +103,7 @@ public class ScmpEchoDemo {
     send();
   }
 
-  private void errorListener(Scmp.ScmpMessage msg) {
+  private void errorListener(Scmp.Message msg) {
     Scmp.ScmpTypeCode code = msg.getTypeCode();
     String millies = getPassedMillies();
     println("SCMP error (after " + millies + "ms): " + code.getText() + " (" + code + ")");
@@ -129,9 +129,8 @@ public class ScmpEchoDemo {
     ByteBuffer data = ByteBuffer.allocate(0);
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
       for (int i = 0; i < 5; i++) {
-        Scmp.Result<Scmp.ScmpEcho> result = scmpChannel.sendEchoRequest(i, data);
-        Scmp.ScmpEcho msg = result.getMessage();
-        String millis = String.format("%.4f", result.getNanoSeconds() / (double) 1_000_000);
+        Scmp.EchoResult msg = scmpChannel.sendEchoRequest(i, data);
+        String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();
         echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();
         echoMsgStr += " time=" + millis + "ms";

--- a/src/test/java/org/scion/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/demo/ScmpEchoDemo.java
@@ -95,7 +95,7 @@ public class ScmpEchoDemo {
     }
   }
 
-  private void echoListener(Scmp.EchoPacket msg) {
+  private void echoListener(Scmp.EchoMessage msg) {
     String echoMsgStr = msg.getTypeCode().getText();
     echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();
     echoMsgStr += " time=" + getPassedMillies() + "ms";
@@ -129,7 +129,7 @@ public class ScmpEchoDemo {
     ByteBuffer data = ByteBuffer.allocate(0);
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
       for (int i = 0; i < 10; i++) {
-        Scmp.EchoPacket msg = scmpChannel.sendEchoRequest(i, data);
+        Scmp.EchoMessage msg = scmpChannel.sendEchoRequest(i, data);
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();
         echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();

--- a/src/test/java/org/scion/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/demo/ScmpEchoDemo.java
@@ -95,7 +95,7 @@ public class ScmpEchoDemo {
     }
   }
 
-  private void echoListener(Scmp.EchoResult msg) {
+  private void echoListener(Scmp.EchoPacket msg) {
     String echoMsgStr = msg.getTypeCode().getText();
     echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();
     echoMsgStr += " time=" + getPassedMillies() + "ms";
@@ -129,7 +129,7 @@ public class ScmpEchoDemo {
     ByteBuffer data = ByteBuffer.allocate(0);
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
       for (int i = 0; i < 10; i++) {
-        Scmp.EchoResult msg = scmpChannel.sendEchoRequest(i, data);
+        Scmp.EchoPacket msg = scmpChannel.sendEchoRequest(i, data);
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();
         echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();

--- a/src/test/java/org/scion/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/demo/ScmpEchoDemo.java
@@ -128,7 +128,7 @@ public class ScmpEchoDemo {
 
     ByteBuffer data = ByteBuffer.allocate(0);
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
-      for (int i = 0; i < 5; i++) {
+      for (int i = 0; i < 10; i++) {
         Scmp.EchoResult msg = scmpChannel.sendEchoRequest(i, data);
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();

--- a/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
@@ -102,8 +102,8 @@ public class ScmpTracerouteDemo {
     System.out.println("Listening at port " + localPort + " ...");
 
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
-      Collection<Scmp.TraceroutePacket> results = scmpChannel.sendTracerouteRequest();
-      for (Scmp.TraceroutePacket msg : results) {
+      Collection<Scmp.TracerouteMessage> results = scmpChannel.sendTracerouteRequest();
+      for (Scmp.TracerouteMessage msg : results) {
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();
         echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();

--- a/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
@@ -80,6 +80,7 @@ public class ScmpTracerouteDemo {
           // Port must be 30041 for networks that expect a dispatcher
           ScmpTracerouteDemo demo = new ScmpTracerouteDemo(30041);
           demo.runDemo(DemoConstants.iaAnapayaHK);
+          // demo.runDemo(DemoConstants.iaOVGU);
           break;
         }
     }
@@ -101,7 +102,7 @@ public class ScmpTracerouteDemo {
     System.out.println("Listening at port " + localPort + " ...");
 
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
-      Collection<Scmp.TracerouteResult> results = scmpChannel.sendTracerouteRequest();
+      Collection<Scmp.TracerouteResult> results = scmpChannel.sendTracerouteRequestOld();
       for (Scmp.TracerouteResult msg : results) {
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();

--- a/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
@@ -102,7 +102,7 @@ public class ScmpTracerouteDemo {
     System.out.println("Listening at port " + localPort + " ...");
 
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
-      Collection<Scmp.TracerouteResult> results = scmpChannel.sendTracerouteRequestOld();
+      Collection<Scmp.TracerouteResult> results = scmpChannel.sendTracerouteRequest();
       for (Scmp.TracerouteResult msg : results) {
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();

--- a/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
@@ -102,8 +102,8 @@ public class ScmpTracerouteDemo {
     System.out.println("Listening at port " + localPort + " ...");
 
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
-      Collection<Scmp.TracerouteResult> results = scmpChannel.sendTracerouteRequest();
-      for (Scmp.TracerouteResult msg : results) {
+      Collection<Scmp.TraceroutePacket> results = scmpChannel.sendTracerouteRequest();
+      for (Scmp.TraceroutePacket msg : results) {
         String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();
         echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();

--- a/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/demo/ScmpTracerouteDemo.java
@@ -101,10 +101,9 @@ public class ScmpTracerouteDemo {
     System.out.println("Listening at port " + localPort + " ...");
 
     try (ScmpChannel scmpChannel = Scmp.createChannel(path, localPort)) {
-      Collection<Scmp.Result<Scmp.ScmpTraceroute>> results = scmpChannel.sendTracerouteRequest();
-      for (Scmp.Result<Scmp.ScmpTraceroute> r : results) {
-        Scmp.ScmpTraceroute msg = r.getMessage();
-        String millis = String.format("%.4f", r.getNanoSeconds() / (double) 1_000_000);
+      Collection<Scmp.TracerouteResult> results = scmpChannel.sendTracerouteRequest();
+      for (Scmp.TracerouteResult msg : results) {
+        String millis = String.format("%.4f", msg.getNanoSeconds() / (double) 1_000_000);
         String echoMsgStr = msg.getTypeCode().getText();
         echoMsgStr += " scmp_seq=" + msg.getSequenceNumber();
         echoMsgStr += " " + ScionUtil.toStringIA(msg.getIsdAs()) + " IfID=" + msg.getIfID();

--- a/src/test/java/org/scion/demo/inspector/HopField.java
+++ b/src/test/java/org/scion/demo/inspector/HopField.java
@@ -26,18 +26,21 @@ public class HopField {
   private boolean r3;
   private boolean r4;
   private boolean r5;
-  private boolean r6;
-  //  1 bit : ConsIngress Router Alert. If the ConsIngress Router Alert is set, the ingress router
-  //  (in construction direction) will process the L4 payload in the packet.
+  /**
+   * 1 bit : ConsIngress Router Alert. If the ConsIngress Router Alert is set, the ingress router
+   * (in construction direction) will process the L4 payload in the packet.
+   */
   private boolean flagI;
-  //  1 bit : ConsEgress Router Alert. If the ConsEgress Router Alert is set, the egress router
-  //  (in construction direction) will process the L4 payload in the packet.
+  /**
+   * 1 bit : ConsEgress Router Alert. If the ConsEgress Router Alert is set, the egress router (in
+   * construction direction) will process the L4 payload in the packet.
+   */
   private boolean flagE;
-  //  8 bits : Expiry time of a hop field. The expiration time expressed is relative. An absolute
-  // expiration time
-  //  in seconds is computed in combination with the timestamp field (from the corresponding info
-  // field) as follows:
-  //  abs_time = timestamp + (1+expiryTime)*24*60*60/256
+  /**
+   * 8 bits : Expiry time of a hop field. The expiration time expressed is relative. An absolute
+   * expiration time in seconds is computed in combination with the timestamp field (from the
+   * corresponding info field) as follows: abs_time = timestamp + (1+expiryTime)*24*60*60/256
+   */
   private int expiryTime;
   // 16 bits : consIngress : The 16-bits ingress interface IDs in construction direction.
   private int consIngress;
@@ -55,14 +58,13 @@ public class HopField {
     int i0 = data.getInt();
     long l1 = data.getLong();
     r0 = readBoolean(i0, 0);
-    r1 = readBoolean(i0, 0);
-    r2 = readBoolean(i0, 0);
-    r3 = readBoolean(i0, 0);
-    r4 = readBoolean(i0, 0);
-    r5 = readBoolean(i0, 0);
-    r6 = readBoolean(i0, 0);
-    flagI = readBoolean(i0, 0);
-    flagE = readBoolean(i0, 0);
+    r1 = readBoolean(i0, 1);
+    r2 = readBoolean(i0, 2);
+    r3 = readBoolean(i0, 3);
+    r4 = readBoolean(i0, 4);
+    r5 = readBoolean(i0, 5);
+    flagI = readBoolean(i0, 6);
+    flagE = readBoolean(i0, 7);
     expiryTime = readInt(i0, 8, 8);
     consIngress = readInt(i0, 16, 16);
     consEgress = (int) readLong(l1, 0, 16);
@@ -98,8 +100,6 @@ public class HopField {
         + r4
         + ", r5="
         + r5
-        + ", r6="
-        + r6
         + ", I="
         + flagI
         + ", E="
@@ -126,7 +126,6 @@ public class HopField {
     r3 = false;
     r4 = false;
     r5 = false;
-    r6 = false;
     flagI = false;
     flagE = false;
     expiryTime = 0;
@@ -141,5 +140,13 @@ public class HopField {
 
   public int getEgress() {
     return consEgress;
+  }
+
+  public boolean hasIngressAlert() {
+    return flagI;
+  }
+
+  public boolean hasEgressAlert() {
+    return flagE;
   }
 }

--- a/src/test/java/org/scion/demo/inspector/ScionPacketInspector.java
+++ b/src/test/java/org/scion/demo/inspector/ScionPacketInspector.java
@@ -150,7 +150,9 @@ public class ScionPacketInspector {
   public void reversePath() {
     scionHeader.reverse();
     pathHeaderScion.reverse();
-    overlayHeaderUdp.reverse();
+    if (scionHeader.nextHeader() == Constants.HdrTypes.UDP) {
+      overlayHeaderUdp.reverse();
+    }
   }
 
   public void writePacket(ByteBuffer newData, byte[] userData) {

--- a/src/test/java/org/scion/demo/inspector/ScmpHeader.java
+++ b/src/test/java/org/scion/demo/inspector/ScmpHeader.java
@@ -125,4 +125,9 @@ public class ScmpHeader {
   public byte[] getUserData() {
     return echoUserData;
   }
+
+  public void setTraceData(long isdAs, int ifID) {
+    this.traceIsdAs = isdAs;
+    this.traceIfID = ifID;
+  }
 }

--- a/src/test/java/org/scion/testutil/MockNetwork.java
+++ b/src/test/java/org/scion/testutil/MockNetwork.java
@@ -316,13 +316,13 @@ class MockBorderRouter implements Runnable {
     logger.info(
         " received SCMP " + scmpMsg.getTypeCode().name() + " " + scmpMsg.getTypeCode().getText());
 
-    if (scmpMsg instanceof Scmp.EchoPacket) {
+    if (scmpMsg instanceof Scmp.EchoMessage) {
       // send back!
       // This is very basic:
       // - we always answer regardless of whether we are actually the destination.
       // - We do not invert path / addresses
       sendScmp(Scmp.ScmpTypeCode.TYPE_129, buffer, srcAddress, incoming);
-    } else if (scmpMsg instanceof Scmp.TraceroutePacket) {
+    } else if (scmpMsg instanceof Scmp.TracerouteMessage) {
       answerTraceRoute(buffer, srcAddress, incoming);
     } else {
       // forward error

--- a/src/test/java/org/scion/testutil/MockNetwork.java
+++ b/src/test/java/org/scion/testutil/MockNetwork.java
@@ -312,7 +312,9 @@ class MockBorderRouter implements Runnable {
     buffer.position(ScionHeaderParser.extractHeaderLength(buffer));
     ResponsePath path =
         PackageVisibilityHelper.getResponsePath(buffer, (InetSocketAddress) srcAddress);
-    Scmp.Message scmpMsg = ScmpParser.consume(buffer, path);
+    Scmp.ScmpType type = ScmpParser.extractType(buffer);
+    Scmp.Message scmpMsg =
+        ScmpParser.consume(buffer, PackageVisibilityHelper.createMessage(type, path));
     logger.info(
         " received SCMP " + scmpMsg.getTypeCode().name() + " " + scmpMsg.getTypeCode().getText());
 

--- a/src/test/java/org/scion/testutil/MockNetwork.java
+++ b/src/test/java/org/scion/testutil/MockNetwork.java
@@ -309,11 +309,11 @@ class MockBorderRouter implements Runnable {
     buffer.position(ScionHeaderParser.extractHeaderLength(buffer));
     ResponsePath path =
         PackageVisibilityHelper.getResponsePath(buffer, (InetSocketAddress) srcAddress);
-    Scmp.ScmpMessage scmpMsg = ScmpParser.consume(buffer, path);
+    Scmp.Message scmpMsg = ScmpParser.consume(buffer, path);
     logger.info(
         " received SCMP " + scmpMsg.getTypeCode().name() + " " + scmpMsg.getTypeCode().getText());
 
-    if (scmpMsg instanceof Scmp.ScmpEcho) {
+    if (scmpMsg instanceof Scmp.EchoResult) {
       // send back!
       // This is very basic:
       // - we always answer regardless of whether we are actually the destination.
@@ -328,7 +328,7 @@ class MockBorderRouter implements Runnable {
       //      out.flip();
       //      incoming.send(out, srcAddress);
       //      buffer.clear();
-    } else if (scmpMsg instanceof Scmp.ScmpTraceroute) {
+    } else if (scmpMsg instanceof Scmp.TracerouteResult) {
       // send back!
       // This is very basic:
       // - we always answer regardless of whether we are actually the destination.

--- a/src/test/java/org/scion/testutil/MockNetwork.java
+++ b/src/test/java/org/scion/testutil/MockNetwork.java
@@ -33,7 +33,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.scion.PackageVisibilityHelper;
 import org.scion.ResponsePath;
+import org.scion.ScionUtil;
 import org.scion.Scmp;
+import org.scion.demo.inspector.HopField;
+import org.scion.demo.inspector.PathHeaderScion;
 import org.scion.demo.inspector.ScionPacketInspector;
 import org.scion.demo.inspector.ScmpHeader;
 import org.scion.internal.ScionHeaderParser;
@@ -44,30 +47,21 @@ import org.slf4j.LoggerFactory;
 public class MockNetwork {
 
   public static final String BORDER_ROUTER_HOST = "127.0.0.1";
-  private static final int BORDER_ROUTER_PORT1 = 30555;
-  private static final int BORDER_ROUTER_PORT2 = 30556;
   public static final String TINY_SRV_ADDR_1 = "127.0.0.112";
   public static final int TINY_SRV_PORT_1 = 22233;
   public static final String TINY_SRV_ISD_AS = "1-ff00:0:112";
   public static final String TINY_SRV_NAME_1 = "server.as112.test";
+  static final AtomicInteger nForwardTotal = new AtomicInteger();
+  static final AtomicIntegerArray nForwards = new AtomicIntegerArray(20);
+  static final AtomicInteger dropNextPackets = new AtomicInteger();
+  static final AtomicReference<Scmp.ScmpTypeCode> scmpErrorOnNextPacket = new AtomicReference<>();
+  private static final int BORDER_ROUTER_PORT1 = 30555;
+  private static final int BORDER_ROUTER_PORT2 = 30556;
   private static final Logger logger = LoggerFactory.getLogger(MockNetwork.class.getName());
   private static ExecutorService routers = null;
   private static MockDaemon daemon = null;
-  static final AtomicInteger nForwardTotal = new AtomicInteger();
-  static final AtomicIntegerArray nForwards = new AtomicIntegerArray(20);
   private static MockTopologyServer topoServer;
   private static MockControlServer controlServer;
-  static final AtomicInteger dropNextPackets = new AtomicInteger();
-  static final AtomicReference<Scmp.ScmpTypeCode> scmpErrorOnNextPacket = new AtomicReference<>();
-
-  public enum Mode {
-    /** Start daemon */
-    DAEMON,
-    /** Install bootstrap server with DNS NAPTR record */
-    NAPTR,
-    /** Install bootstrap server */
-    BOOTSTRAP
-  }
 
   /**
    * Start a network with one daemon and a border router. The border router connects "1-ff00:0:110"
@@ -190,6 +184,15 @@ public class MockNetwork {
 
   public static MockControlServer getControlServer() {
     return controlServer;
+  }
+
+  public enum Mode {
+    /** Start daemon */
+    DAEMON,
+    /** Install bootstrap server with DNS NAPTR record */
+    NAPTR,
+    /** Install bootstrap server */
+    BOOTSTRAP
   }
 }
 
@@ -319,30 +322,8 @@ class MockBorderRouter implements Runnable {
       // - we always answer regardless of whether we are actually the destination.
       // - We do not invert path / addresses
       sendScmp(Scmp.ScmpTypeCode.TYPE_129, buffer, srcAddress, incoming);
-      //      buffer.rewind();
-      //      ScionPacketInspector spi = ScionPacketInspector.readPacket(buffer);
-      //      ScmpHeader scmpHeader = spi.getScmpHeader();
-      //      scmpHeader.setCode(Scmp.ScmpTypeCode.TYPE_129);
-      //      ByteBuffer out = ByteBuffer.allocate(100);
-      //      spi.writePacketSCMP(out);
-      //      out.flip();
-      //      incoming.send(out, srcAddress);
-      //      buffer.clear();
     } else if (scmpMsg instanceof Scmp.TracerouteResult) {
-      // send back!
-      // This is very basic:
-      // - we always answer regardless of whether we are actually the destination.
-      // - We do not invert path / addresses
-      sendScmp(Scmp.ScmpTypeCode.TYPE_131, buffer, srcAddress, incoming);
-      //      buffer.rewind();
-      //      ScionPacketInspector spi = ScionPacketInspector.readPacket(buffer);
-      //      ScmpHeader scmpHeader = spi.getScmpHeader();
-      //      scmpHeader.setCode(Scmp.ScmpTypeCode.TYPE_131);
-      //      ByteBuffer out = ByteBuffer.allocate(100);
-      //      spi.writePacketSCMP(out);
-      //      out.flip();
-      //      incoming.send(out, srcAddress);
-      //      buffer.clear();
+      answerTraceRoute(buffer, srcAddress, incoming);
     } else {
       // forward error
       InetSocketAddress dstAddress = PackageVisibilityHelper.getDstAddress(buffer);
@@ -371,6 +352,33 @@ class MockBorderRouter implements Runnable {
     spi.writePacketSCMP(out);
     out.flip();
     channel.send(out, srcAddress);
+    buffer.clear();
+  }
+
+  private void answerTraceRoute(
+      ByteBuffer buffer, SocketAddress srcAddress, DatagramChannel incoming) throws IOException {
+    // This is very basic:
+    // - we always answer regardless of whether we are actually the destination.
+    buffer.rewind();
+    ScionPacketInspector spi = ScionPacketInspector.readPacket(buffer);
+    spi.reversePath();
+    ScmpHeader scmpHeader = spi.getScmpHeader();
+    scmpHeader.setCode(Scmp.ScmpTypeCode.TYPE_131);
+    PathHeaderScion phs = spi.getPathHeaderScion();
+    for (int i = 0; i < phs.getHopCount(); i++) {
+      HopField hf = phs.getHopField(i);
+      // These answers are hardcoded to work specifically with ScmpTest.traceroute()
+      if (hf.hasEgressAlert()) {
+        scmpHeader.setTraceData(ScionUtil.parseIA("1-ff00:0:112"), 42);
+      }
+      if (hf.hasIngressAlert()) {
+        scmpHeader.setTraceData(ScionUtil.parseIA("1-ff00:0:110"), 42);
+      }
+    }
+    ByteBuffer out = ByteBuffer.allocate(100);
+    spi.writePacketSCMP(out);
+    out.flip();
+    incoming.send(out, srcAddress);
     buffer.clear();
   }
 

--- a/src/test/java/org/scion/testutil/MockNetwork.java
+++ b/src/test/java/org/scion/testutil/MockNetwork.java
@@ -316,13 +316,13 @@ class MockBorderRouter implements Runnable {
     logger.info(
         " received SCMP " + scmpMsg.getTypeCode().name() + " " + scmpMsg.getTypeCode().getText());
 
-    if (scmpMsg instanceof Scmp.EchoResult) {
+    if (scmpMsg instanceof Scmp.EchoPacket) {
       // send back!
       // This is very basic:
       // - we always answer regardless of whether we are actually the destination.
       // - We do not invert path / addresses
       sendScmp(Scmp.ScmpTypeCode.TYPE_129, buffer, srcAddress, incoming);
-    } else if (scmpMsg instanceof Scmp.TracerouteResult) {
+    } else if (scmpMsg instanceof Scmp.TraceroutePacket) {
       answerTraceRoute(buffer, srcAddress, incoming);
     } else {
       // forward error


### PR DESCRIPTION
SCMP refactoring and cleanup

- Rename `Scmp.ScmpXYZ` to `Scmp.XYZ`
- Remove `Result<>`
- Move Scmp code out of DatagramChannel into separate class. Consider creating `AbstractScionChannel`.