### PR TITLE
Rename getConnectionPath()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#18](https://github.com/tzaeschke/phtree-cpp/pull/18)
 - Doc cleanup
   [#22](https://github.com/tzaeschke/phtree-cpp/pull/22)
-
+- BREAKING CHANGE: `getCurrentPath()` renamed to `getConnectionPath()`
+  [#31](https://github.com/tzaeschke/phtree-cpp/pull/31)
 
 ### Fixed
 - Fixed: SCMP problem when pinging local AS.

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -34,7 +34,8 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   private final java.nio.channels.DatagramChannel channel;
   private boolean isConnected = false;
   private InetSocketAddress connection;
-  private RequestPath path;
+  // This path is only used for write() after connect(), not for send()
+  private RequestPath connectionPath;
   private boolean cfgReportFailedValidation = false;
   private PathPolicy pathPolicy = PathPolicy.DEFAULT;
   private ScionService service;
@@ -69,17 +70,19 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   }
 
   /**
-   * Set the path policy. The default path policy is set in PathPolicy.DEFAULT, which currently
-   * means to use the first path returned by the daemon or control service. If the channel is
-   * connected, this method will request a new path using the new policy.
+   * Set the path policy. The default path policy is set in {@link PathPolicy#DEFAULT} If the
+   * channel is connected, this method will request a new path using the new policy.
+   *
+   * <p>After initially setting the path policy, it is used to request a new path during write() and
+   * send() whenever a path turns out to be close to expiration.
    *
    * @param pathPolicy the new path policy
    * @see PathPolicy#DEFAULT
    */
   public synchronized void setPathPolicy(PathPolicy pathPolicy) throws IOException {
     this.pathPolicy = pathPolicy;
-    if (path != null) {
-      updatePath(path);
+    if (connectionPath != null) {
+      updatePath(connectionPath);
     }
   }
 
@@ -112,7 +115,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     channel.disconnect();
     connection = null;
     isConnected = false;
-    path = null;
+    connectionPath = null;
   }
 
   public synchronized boolean isOpen() {
@@ -126,7 +129,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     channel.close();
     isConnected = false;
     connection = null;
-    path = null;
+    connectionPath = null;
   }
 
   /**
@@ -166,7 +169,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   @SuppressWarnings("unchecked")
   public synchronized C connect(RequestPath path) throws IOException {
     checkConnected(false);
-    this.path = path;
+    this.connectionPath = path;
     isConnected = true;
     connection = path.getFirstHopAddress();
     channel.connect(connection);
@@ -174,16 +177,17 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   }
 
   /**
-   * Get the currently connected path.
+   * Get the currently connected path. The connected path is set during {@link
+   * #connect(RequestPath)} and may be refreshed when expired.
    *
    * @return the current Path or `null` if not path is connected.
    */
-  public synchronized Path getCurrentPath() {
-    return path;
+  public synchronized Path getConnectionPath() {
+    return connectionPath;
   }
 
-  protected synchronized void setPath(RequestPath path) {
-    this.path = path;
+  protected synchronized void setConnectionPath(RequestPath path) {
+    this.connectionPath = path;
   }
 
   protected ResponsePath receiveFromChannel(
@@ -209,8 +213,9 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
       // in extensions headers.
       hdrType = receiveExtensionHeader(buffer, hdrType);
 
+      ResponsePath path = ScionHeaderParser.extractResponsePath(buffer, srcAddress);
       if (hdrType == expectedHdrType) {
-        return ScionHeaderParser.extractResponsePath(buffer, srcAddress);
+        return path;
       }
       receiveScmp(buffer, path);
     }
@@ -400,7 +405,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
         this.connection = newPath.getFirstHopAddress();
         channel.connect(this.connection);
       }
-      this.path = newPath;
+      this.connectionPath = newPath;
     }
     return newPath;
   }

--- a/src/main/java/org/scion/DatagramChannel.java
+++ b/src/main/java/org/scion/DatagramChannel.java
@@ -164,7 +164,7 @@ public class DatagramChannel extends AbstractDatagramChannel<DatagramChannel>
 
     int len = src.remaining();
     // + 8 for UDP overlay header length
-    buildHeader(bufferSend, getCurrentPath(), len + 8, InternalConstants.HdrTypes.UDP);
+    buildHeader(bufferSend, getConnectionPath(), len + 8, InternalConstants.HdrTypes.UDP);
     bufferSend.put(src);
     bufferSend.flip();
 

--- a/src/main/java/org/scion/ScmpChannel.java
+++ b/src/main/java/org/scion/ScmpChannel.java
@@ -55,7 +55,7 @@ public class ScmpChannel implements AutoCloseable {
    * @throws IOException if an IO error occurs or if an SCMP error is received.
    */
   public Scmp.EchoMessage sendEchoRequest(int sequenceNumber, ByteBuffer data) throws IOException {
-    RequestPath path = (RequestPath) channel.getCurrentPath();
+    RequestPath path = (RequestPath) channel.getConnectionPath();
     Scmp.EchoMessage request = Scmp.EchoMessage.createRequest(sequenceNumber, path, data);
     sendScmpRequest(() -> channel.sendEchoRequest(request), Scmp.TypeCode.TYPE_129);
     return request;
@@ -72,7 +72,7 @@ public class ScmpChannel implements AutoCloseable {
    */
   public Collection<Scmp.TracerouteMessage> sendTracerouteRequest() throws IOException {
     List<Scmp.TracerouteMessage> requests = new ArrayList<>();
-    RequestPath path = (RequestPath) channel.getCurrentPath();
+    RequestPath path = (RequestPath) channel.getConnectionPath();
     List<PathHeaderParser.Node> nodes = PathHeaderParser.getTraceNodes(path.getRawPath());
     for (int i = 0; i < nodes.size(); i++) {
       Scmp.TracerouteMessage request = Scmp.TracerouteMessage.createRequest(i, path);
@@ -141,7 +141,7 @@ public class ScmpChannel implements AutoCloseable {
       super.channel().configureBlocking(false);
       super.channel().register(selector, SelectionKey.OP_READ);
 
-      super.setPath(path);
+      super.setConnectionPath(path);
       // listen on ANY interface: 0.0.0.0 / [::]
       super.bind(new InetSocketAddress("[::]", port));
     }

--- a/src/test/java/org/scion/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelApiTest.java
@@ -467,7 +467,7 @@ class DatagramChannelApiTest {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongHelper.MSG.getBytes());
           try {
             channel.write(sendBuf);
-            RequestPath newPath = (RequestPath) channel.getCurrentPath();
+            RequestPath newPath = (RequestPath) channel.getConnectionPath();
             assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
             assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
           } catch (IOException e) {
@@ -517,17 +517,17 @@ class DatagramChannelApiTest {
     RequestPath addr = ExamplePacket.PATH;
     ByteBuffer buffer = ByteBuffer.allocate(50);
     try (DatagramChannel channel = DatagramChannel.open()) {
-      assertNull(channel.getCurrentPath());
+      assertNull(channel.getConnectionPath());
 
       // connect should set a path
       channel.connect(addr);
-      assertNotNull(channel.getCurrentPath());
+      assertNotNull(channel.getConnectionPath());
       channel.disconnect();
-      assertNull(channel.getCurrentPath());
+      assertNull(channel.getConnectionPath());
 
       // send should NOT set a path
       channel.send(buffer, addr);
-      assertNull(channel.getCurrentPath());
+      assertNull(channel.getConnectionPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/scion/api/DatagramChannelErrorHandlingTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelErrorHandlingTest.java
@@ -58,12 +58,12 @@ class DatagramChannelErrorHandlingTest {
       RequestPath path1 = paths.get(0);
       channel.connect(path0);
       channel.write(ByteBuffer.allocate(0));
-      assertEquals(path0, channel.getCurrentPath());
+      assertEquals(path0, channel.getConnectionPath());
 
       // TODO Use mock instead of daemon?
       MockNetwork.returnScmpErrorOnNextPacket(Scmp.TypeCode.TYPE_5);
       channel.write(ByteBuffer.allocate(0));
-      assertEquals(path0, channel.getCurrentPath());
+      assertEquals(path0, channel.getConnectionPath());
       assertEquals(1, scmpReceived.get());
       // mock.setSendCallback((byteBuffer,path) -> {});
 


### PR DESCRIPTION
Rename DatagramChannel.getCurrentPath() to getConnectionPath() to better reflect when the path is actually used.