### PR TITLE
Fix DatagramChannel connection tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CI (only) failures on JDK 8. [#10](https://github.com/netsec-ethz/scion-java-client/pull/10)
 - Sporadic CI (only) failures. [#12](https://github.com/netsec-ethz/scion-java-client/pull/12)
 - Small fixes for 0.1.0 release. [#32](https://github.com/netsec-ethz/scion-java-client/pull/32)
+- Fix NPE after 2nd send() in unconnected channel + cleanup. 
+  [#33](https://github.com/netsec-ethz/scion-java-client/pull/33)
 
 ### Removed
 

--- a/src/test/java/org/scion/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelApiTest.java
@@ -41,7 +41,19 @@ import org.scion.testutil.PingPongHelper;
 class DatagramChannelApiTest {
 
   private static final int dummyPort = 44444;
+  private static final InetAddress dummyIPv4;
+  private static final InetSocketAddress dummyAddress;
+  private static final DatagramPacket dummyPacket;
 
+  static {
+    try {
+      dummyIPv4 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+      dummyAddress = new InetSocketAddress(dummyIPv4, dummyPort);
+      dummyPacket = new DatagramPacket(new byte[100], 100, dummyAddress);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
   @BeforeEach
   public void beforeEach() throws IOException {
     MockDaemon.createAndStartDefault();
@@ -494,6 +506,24 @@ class DatagramChannelApiTest {
       assertNull(channel.getConnectionPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testBug_doubleSendCausesNPE() throws IOException {
+    try (DatagramChannel server = DatagramChannel.open()) {
+      server.bind(dummyAddress);
+      try (DatagramChannel client = DatagramChannel.open()) {
+        assertFalse(client.isConnected());
+        assertNull(client.getConnectionPath());
+        assertNull(client.getRemoteAddress());
+        ByteBuffer buffer = ByteBuffer.allocate(50);
+        client.send(buffer, dummyAddress);
+        assertFalse(client.isConnected());
+        // The second send() used to fail with NPE
+        client.send(buffer, dummyAddress);
+        assertFalse(client.isConnected());
+      }
     }
   }
 

--- a/src/test/java/org/scion/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelApiTest.java
@@ -54,6 +54,7 @@ class DatagramChannelApiTest {
       throw new RuntimeException(e);
     }
   }
+
   @BeforeEach
   public void beforeEach() throws IOException {
     MockDaemon.createAndStartDefault();


### PR DESCRIPTION
The DatagramChannel is mixing up connections of the underlying channel (to first hop) and the implemented channel (to a remote host).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-java-client/33)
<!-- Reviewable:end -->
