### PR TITLE
Channel clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#30](https://github.com/netsec-ethz/scion-java-client/pull/30)
 - Cleaned up `MultiMap` utility class 
   [#34](https://github.com/netsec-ethz/scion-java-client/pull/34)
+- Cleaned up `DatagramChannel`: Fixed connect()/disconnect(), improved concurrency,
+  fixed buffer resizing wrt MTU, general clean up.
+  [#35](https://github.com/netsec-ethz/scion-java-client/pull/35)
 
 ### Fixed
 - Fixed: SCMP problem when pinging local AS.

--- a/doc/Design.md
+++ b/doc/Design.md
@@ -1,11 +1,13 @@
 # Design
 
 We should look at other custom Java protocol implementations, e.g. for QUIC:
+
 * https://github.com/ptrd/kwik
 * https://github.com/trensetim/quic
 * https://kachayev.github.io/quiche4j/
 
 ## Daemon
+
 The implementation can use the daemon. Alternatively, since daemon installation may
 be cumbersome on platforms such as Android, we can directly connect to a control service.
 
@@ -20,10 +22,10 @@ at least a topology server + control server.
 Server functionality, such as `open()` and `receive()` -> `send(RequestPath)`, should _not_ require
 any access to a daemon or control service. The main reason is that it ensures efficiency
 by completely avoiding any type of interaction with daemon/CS.
-Interaction with daemon/CS should not be denied but it should not occur during default operations. 
+Interaction with daemon/CS should not be denied but it should not occur during default operations.
 
 Client functionality will usually require a `ScionService`. If none is provided during `open()`,
-a service will internally be requested via `Scion.defaultService()`. 
+a service will internally be requested via `Scion.defaultService()`.
 While explicit initialization is usually preferable as a design choice, this implicit
 initialization was implemented to allow usage of `open()` without additional arguments.
 This allows being much closer to the native Java `DatagramChannel` API.
@@ -37,20 +39,21 @@ is actually able to connect to something.
 ## ScionService
 
 The `ScionService` implements all interactions with a local daemon or with a control service.
-When a `ScionService` is required internally (e.g. by `DatagramChannel`) and none has been 
-specified, a `ScionService` will be requested (and if none has been created yet, created) via 
-`Scion.defaultService()`. 
+When a `ScionService` is required internally (e.g. by `DatagramChannel`) and none has been
+specified, a `ScionService` will be requested (and if none has been created yet, created) via
+`Scion.defaultService()`.
 
 A `ScionService` created via specific factory methods (`Scion.newServiceWithDNS`, etc) will _not_ be
 used or returned by `Scion.defaultService()`.
 
 ## Library dependencies etc
 
-- Use Maven (instead of Gradle or something else): Maven is still the most used framework and arguable the best (
+- Use Maven (instead of Gradle or something else): Maven is still the most used framework and
+  arguable the best (
   convention over configuration)
 - Use Java 8: Still the most used JDK (TODO provide reference).
-  - Main problem: no module support
-  - E.g. **netty** is on Java 8 (distributed libraries are JDK 6), **jetty** is on 11/17
+    - Main problem: no module support
+    - E.g. **netty** is on Java 8 (distributed libraries are JDK 6), **jetty** is on 11/17
 - Logging:
     - Do not use special log classes for JDK plugin classes (DatagramSocket etc)
     - Consider using `slfj4` logging framework for other classes: widely used ond flexible.
@@ -62,83 +65,133 @@ used or returned by `Scion.defaultService()`.
 ## Paths
 
 There are two types of paths (both inherit `Path`:
-- `RequestPath` are used to send initial request. They are retrieved from a path service and contain meta information.
+
+- `RequestPath` are used to send initial request. They are retrieved from a path service and contain
+  meta information.
 - `ResponsePath` are used to respond to a client request. They are extracted from SCION packets.
 
 `Path` contains a destination IA:IP:port, a raw path and a first hop IP:port.
 `RequestPath` also contains path meta information.
 `ResponsePath` also contains origin IA:IP:port.
 
-
 ## DatagramSocket
 
 **DatagramSocket is not really supported, please use DatagramChannel instead.**
 
 Some problems with DatagramSocket:
+
 - It is not possible to associate a ScionAddress or ScionSocketAddress with a Datagram.
-  This is problematic when sending a datagram, especially on the server side, because 
+  This is problematic when sending a datagram, especially on the server side, because
   we cannot associate a path with a datagram. The Socket will have to remember **all** incoming
   paths so that it has a path when returning a datagram to a client.
-  This may improve somewhat in future if we get reverse lookup for IP addresses -> ISD/AS; 
+  This may improve somewhat in future if we get reverse lookup for IP addresses -> ISD/AS;
   this would allow the socket to forget paths and get new ones from the reverse lookup.
-- It is not possible to subclass InetAddress which is the address type that is store inside 
+- It is not possible to subclass InetAddress which is the address type that is store inside
   DatagramPackets.
 
-
 Datagram Socket design considerations:
+
 - Java 15 has a new Implementation based on NIO, see https://openjdk.org/jeps/373
-  - If Java 8's NIO is sufficient, we can follow the same approach as Java 15.
-    Otherwise we can (as proposed in JEP 373) wrap around an old DatagramSocket and use
-    the nio implementation only when it is available (running on JDK 15 or later).
-    See also deprecation note: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/DatagramSocket.html#setDatagramSocketImplFactory(java.net.DatagramSocketImplFactory)
+    - If Java 8's NIO is sufficient, we can follow the same approach as Java 15.
+      Otherwise we can (as proposed in JEP 373) wrap around an old DatagramSocket and use
+      the nio implementation only when it is available (running on JDK 15 or later).
+      See also deprecation
+      note: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/DatagramSocket.html#setDatagramSocketImplFactory(java.net.DatagramSocketImplFactory)
+- Implementation using DatagramSocketImpl is also not possible because it does not allow
+  overriding getRemoteAddress() etc. These methods should return the address of the remote
+  end host.
+  The only viable solution appears to be to reimplement DatagramSocket.
 
 - **Copy buffers?** We copy a packet's data array to a new DatagramPacket for the user.
   The alternative would be to use offset/length, however, this would not be really
   pluggable because user would need to respect SCION header sizes when creating buffers for packets.
-  - Replacing the buffer in the user's packet is bad, this may be surprising for users
-  - Using the buffer directly to read SCION packets is also bad because it may be too small
-  - --> We definitely need to copy.
-- **Inherit DatagramSocket?** For now we do not inherit DatagramSocket.
-  - Making DatagramSocket a super class of ScionDatagramSocket can easily be done later on.
-  - Disadvantages 
-    - When the JDK adds methods to DatagramSocket, these are initially not implemented
-      in our implementation and may cause erroneous behavior. 
-    - Implementing missing methods later on is difficult because it may not be compatible with
-      earlier JDK version. At the very least, we cannot use `@Override`.
-  - Advantages
-    - Better "plugability", users can use a variable of type DatagramSocket to store
-      a `ScionDatagramSocket`.
-
+    - Replacing the buffer in the user's packet is bad, this may be surprising for users
+    - Using the buffer directly to read SCION packets is also bad because it may be too small
+    - --> We definitely need to copy.
 
 ## Paths
 
 ### Path & Header retainment
+
 - Paths & Headers are retained for:
-  - efficiency (when sending multiple times to the same destination)
-  - reversing the path
+    - efficiency (when sending multiple times to the same destination)
+    - reversing the path
 - Path are not associated with DatagramChannels. That means:
-  - They can be reused in other Channels -> TODO they need to be thread-safe / immutable
-  - An incoming path may be used to create a separate outgoing channel
-  
+    - They can be reused in other Channels -> TODO they need to be thread-safe / immutable
+    - An incoming path may be used to create a separate outgoing channel
+
 **Questions - TODO:**
+
 - Should the PathService retain paths, as a form of cache?
-- When a client receives a packet and wants to send another one, should it reuse the original 
-  path or revert the incoming path? 
+- When a client receives a packet and wants to send another one, should it reuse the original
+  path or revert the incoming path?
+
+### Local Address
+
+When sending a packet, the path must include a valid return address (IP+port).
+Finding out the local IP address can be non-trivial.
+
+`DatagramChannel.getLocalAddress()` may return the correct address.
+However, it may also return `null` (if not bound or connected) an IP address with port `0`,
+a wildcard address (`0.0.0.0`), a link-local address or a site-local address.
+
+Even if `getLocalAddress()` returns a good external address, there are more problems.
+For example, if the route changes, the first hop may change and be reachable via a different
+interface. Also, with concurrent usage, the channel/socket may be actively listening while we may
+need to change the outgoing interface.
+
+How do we solve this?
+
+We should always listen on the wildcard address to ensure we always receive returned
+traffic regardless on which interface it arrives.
+However, this prevents situations where different services listen on identical ports on
+different interfaces (is this a realistic scenario?).
+
+Using the IP of the first hop, we could check all local interfaces and try to select one
+that is likely reachable by the first hop border router.
+We use this interface IP as return address in the SCION path.
+
+#### Solution
+
+1) If the channel is explicitly (by the user) bound to a specific interface
+   then we use that interface as return address.
+    * If it turns out that the bound interface is on a different
+      network than the first hop, then we could throw an exception.
+    * Instead of throwing an exception, we could also
+      try to look for a path that has a first hop compatible with the
+      bound interface.
+2) If the channel is not bound or bound to a wildcard address, we can:
+    * either check all interfaces to find one that is likely to be
+      reachable by the first hop border router.
+    * or open s separate channel/socket and connect() to the first hop.
+3) Selection of the return IP must be done every time the path changes:
+    * Path expires
+    * First hop becomes unreachable or interfaces appear dynamically due to topology changes 
+      (e.g. mobile WiFi or 5G)
+    * Explicit path change requested by user.
+
+Situations with link local or site local addresses can only
+be ignored. If the first hop is reachable via these addresse
+
+We used to use `connnect(firstHop)` to ensure a valid external IP. However,
+`connect()` blocks when used concurrently while a `receive()` is in progress.
+-> Solution: Use separate channel/socket with `connect()` to find external IP.
 
 # TODO
 
 ## DatagramChannel
 
 ### Comments
+
 * Selectors: Implementing a selectable Channel intentionally requires reimplementing
   the whole Selector infrastructure, see also https://bugs.openjdk.org/browse/JDK-8191884.
 
 ## DatagramSocket
 
-**DatagramSockets are currently not supported and may never be supported**. 
+**DatagramSockets are currently not supported and may never be supported**.
 DatagramSockets have no means of handling paths transparently (see discussion above).
 That means we would need additional functions for sending/receiving SCION packets.
-This is possible but usage is not transparent and inconvenient. 
+This is possible but usage is not transparent and inconvenient.
 
 * [ ] Multicast support, check
   e.g. [javadoc](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/DatagramSocket.html)

--- a/src/main/java/org/scion/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/AbstractDatagramChannel.java
@@ -23,6 +23,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.NotYetConnectedException;
 import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import org.scion.internal.ExtensionHeader;
 import org.scion.internal.InternalConstants;
@@ -32,9 +34,17 @@ import org.scion.internal.ScmpParser;
 abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> implements Closeable {
 
   private final java.nio.channels.DatagramChannel channel;
+  private ByteBuffer bufferReceive;
+  private ByteBuffer bufferSend;
+
+  private final Object stateLock = new Object();
+  private final ReentrantLock readLock = new ReentrantLock();
+  private final ReentrantLock writeLock = new ReentrantLock();
+
   // This path is only used for write() after connect(), not for send().
   // Whether we have a connectionPath is independent of whether the underlying channel is connected.
   private RequestPath connectionPath;
+  private InetAddress localAddress;
   private boolean cfgReportFailedValidation = false;
   private PathPolicy pathPolicy = PathPolicy.DEFAULT;
   private ScionService service;
@@ -43,6 +53,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
           Constants.PROPERTY_PATH_EXPIRY_MARGIN,
           Constants.ENV_PATH_EXPIRY_MARGIN,
           Constants.DEFAULT_PATH_EXPIRY_MARGIN);
+  private int cfgTrafficClass;
   private Consumer<Scmp.Message> errorListener;
 
   protected AbstractDatagramChannel(ScionService service) throws IOException {
@@ -53,19 +64,27 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
       ScionService service, java.nio.channels.DatagramChannel channel) {
     this.channel = channel;
     this.service = service;
+    this.bufferReceive = ByteBuffer.allocateDirect(2000);
+    this.bufferSend = ByteBuffer.allocateDirect(2000);
   }
 
-  protected synchronized void configureBlocking(boolean block) throws IOException {
-    channel.configureBlocking(block);
+  protected void configureBlocking(boolean block) throws IOException {
+    synchronized (stateLock) {
+      channel.configureBlocking(block);
+    }
   }
 
   // `protected` because it should not be visible in ScmpChannel API.
-  protected synchronized boolean isBlocking() {
-    return channel.isBlocking();
+  protected boolean isBlocking() {
+    synchronized (stateLock) {
+      return channel.isBlocking();
+    }
   }
 
-  public synchronized PathPolicy getPathPolicy() {
-    return this.pathPolicy;
+  public PathPolicy getPathPolicy() {
+    synchronized (stateLock) {
+      return this.pathPolicy;
+    }
   }
 
   /**
@@ -78,36 +97,70 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
    * @param pathPolicy the new path policy
    * @see PathPolicy#DEFAULT
    */
-  public synchronized void setPathPolicy(PathPolicy pathPolicy) throws IOException {
-    this.pathPolicy = pathPolicy;
-    if (connectionPath != null) {
-      updatePath(connectionPath);
+  public void setPathPolicy(PathPolicy pathPolicy) throws IOException {
+    synchronized (stateLock) {
+      this.pathPolicy = pathPolicy;
+      if (isConnected()) {
+        connectionPath = pathPolicy.filter(getOrCreateService().getPaths(connectionPath));
+        updateConnection(connectionPath, true);
+      }
     }
   }
 
-  public synchronized ScionService getOrCreateService() {
-    if (service == null) {
-      service = ScionService.defaultService();
+  public ScionService getOrCreateService() {
+    synchronized (stateLock) {
+      if (service == null) {
+        service = ScionService.defaultService();
+      }
+      return this.service;
     }
-    return this.service;
   }
 
-  public synchronized ScionService getService() {
-    return this.service;
+  public ScionService getService() {
+    synchronized (stateLock) {
+      return this.service;
+    }
   }
 
   protected DatagramChannel channel() {
-    return channel;
+    synchronized (stateLock) {
+      return channel;
+    }
   }
 
   @SuppressWarnings("unchecked")
-  public synchronized C bind(InetSocketAddress address) throws IOException {
-    channel.bind(address);
-    return (C) this;
+  public C bind(InetSocketAddress address) throws IOException {
+    synchronized (stateLock) {
+      channel.bind(address);
+      localAddress = ((InetSocketAddress) channel.getLocalAddress()).getAddress();
+      return (C) this;
+    }
   }
 
-  public synchronized InetSocketAddress getLocalAddress() throws IOException {
-    return (InetSocketAddress) channel.getLocalAddress();
+  private void ensureBound() throws IOException {
+    synchronized (stateLock) {
+      if (localAddress == null) {
+        bind(null);
+      }
+    }
+  }
+
+  /**
+   * Returns the local address. Note that this may change as the path changes, e.g. if we connect to
+   * a new border router on a different network interface.
+   *
+   * @see DatagramChannel#getLocalAddress()
+   * @return The local address.
+   * @throws IOException If an I/O error occurs
+   */
+  public InetSocketAddress getLocalAddress() throws IOException {
+    synchronized (stateLock) {
+      if (localAddress == null) {
+        return null;
+      }
+      int port = ((InetSocketAddress) channel.getLocalAddress()).getPort();
+      return new InetSocketAddress(localAddress, port);
+    }
   }
 
   public SocketAddress getRemoteAddress() throws UnknownHostException {
@@ -119,21 +172,26 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     return null;
   }
 
-  public synchronized void disconnect() throws IOException {
-    channel.disconnect();
-    connectionPath = null;
+  public void disconnect() throws IOException {
+    synchronized (stateLock) {
+      channel.disconnect();
+      connectionPath = null;
+    }
   }
 
-  public synchronized boolean isOpen() {
-    return channel.isOpen();
+  public boolean isOpen() {
+    synchronized (stateLock) {
+      return channel.isOpen();
+    }
   }
 
   @Override
-  // TODO not synchronized yet, think about a more fine grained lock (see JDK Channel impl)
   public void close() throws IOException {
-    channel.disconnect();
-    channel.close();
-    connectionPath = null;
+    synchronized (stateLock) {
+      channel.disconnect();
+      channel.close();
+      connectionPath = null;
+    }
   }
 
   /**
@@ -148,38 +206,74 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
    * @return This channel.
    * @throws IOException for example when the first hop (border router) cannot be connected.
    */
-  public synchronized C connect(SocketAddress addr) throws IOException {
-    checkConnected(false);
-    if (!(addr instanceof InetSocketAddress)) {
-      throw new IllegalArgumentException(
-          "connect() requires an InetSocketAddress or a ScionSocketAddress.");
+  public C connect(SocketAddress addr) throws IOException {
+    synchronized (stateLock) {
+      checkConnected(false);
+      if (!(addr instanceof InetSocketAddress)) {
+        throw new IllegalArgumentException(
+            "connect() requires an InetSocketAddress or a ScionSocketAddress.");
+      }
+      return connect(pathPolicy.filter(getOrCreateService().getPaths((InetSocketAddress) addr)));
     }
-    return connect(pathPolicy.filter(getOrCreateService().getPaths((InetSocketAddress) addr)));
   }
 
   /**
    * Connect to a destination host. Note:<br>
    * - A SCION channel will internally connect to the next border router (first hop) instead of the
    * remote host. <br>
-   * - The path will be replaced with a new path once it is expired.
-   *
-   * <p>
+   * - The path will be replaced with a new path once it is expired.<br>
    *
    * <p>NB: This method does internally not call {@link
-   * java.nio.channels.DatagramChannel}.connect(), instead it calls bind(). That means this method
-   * does NOT perform any additional security checks associated with connect(), only those
-   * associated with bind().
+   * java.nio.channels.DatagramChannel}.connect(). That means this method does NOT perform any
+   * additional security checks associated with connect(). It will however perform a `bind(null)`
+   * unless the channel is already bound.
+   *
+   * <p>"connect()" is understood to provide connect to a destination address (IP+port).<br>
+   * - send()ing packet to another destination will cause an Exception.<br>
+   * - packets received from a different destination will be dropped.<br>
+   * - connecting to a given Path only connects to the destination address, the path (route) itself
+   * may change, i.e. different border routers may be used.
    *
    * @param path Path to the remote host.
    * @return This channel.
    * @throws IOException for example when the first hop (border router) cannot be connected.
    */
   @SuppressWarnings("unchecked")
-  public synchronized C connect(RequestPath path) throws IOException {
-    checkConnected(false);
-    this.connectionPath = path;
-    channel.connect(path.getFirstHopAddress());
-    return (C) this;
+  public C connect(RequestPath path) throws IOException {
+    // For reference: Java DatagramChannel behavior:
+    // - fresh channel has getLocalAddress() == null
+    // - connect() and send() cause internal bind()
+    //   -> bind() after connect() or send() causes AlreadyBoundException
+    //   - send(), receive() and bind(null) bind to ANY
+    // - connect() and bind() have lock conflict with concurrent call to receiver()
+    // - connect() after bind() is fine, but it changes the local address from ANY to specific IF
+
+    // We have two manage two connection states, internal (state of the internallly used channel)
+    // and external (as reported to API users).
+
+    // Externally, for an API user:
+    // Our policy is that a connection only determines the _address_ of the remote host,
+    // the _route_ to the remote host (i.e. border routers) may change.
+    //
+    // Internally:
+    // However, internally, we do _not_ connect() to the first hop.
+    // Usually, connections prevent receiving/sending packets to other IPs.
+    // Since this IP (which is the first hop) may change, which would require us to disconnect() and
+    // re-connect(), which causes two problems:
+    // a) connect() may block infinitely if a receive() is in progress and
+    // b) disconnect() sets the local port to 0
+    //    (before JDK 14, see https://bugs.openjdk.org/browse/JDK-8231880).
+    //
+    // Again, externally:
+    // We still need to make getLocalAddress() return a local IP after connect() so
+    // we call bind(null). We have to do it here, and not lazily during getLocalAddress(),
+    // because bind() may block when a concurrent receive() is on progress.
+    synchronized (stateLock) {
+      checkConnected(false);
+      ensureBound();
+      updateConnection(path, false);
+      return (C) this;
+    }
   }
 
   /**
@@ -188,16 +282,15 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
    *
    * @return the current Path or `null` if not path is connected.
    */
-  public synchronized Path getConnectionPath() {
-    return connectionPath;
-  }
-
-  protected synchronized void setConnectionPath(RequestPath path) {
-    this.connectionPath = path;
+  public Path getConnectionPath() {
+    synchronized (stateLock) {
+      return connectionPath;
+    }
   }
 
   protected ResponsePath receiveFromChannel(
       ByteBuffer buffer, InternalConstants.HdrTypes expectedHdrType) throws IOException {
+    ensureBound();
     while (true) {
       buffer.clear();
       InetSocketAddress srcAddress = (InetSocketAddress) channel.receive(buffer);
@@ -249,8 +342,10 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   }
 
   protected void checkListeners(Scmp.Message scmpMsg) {
-    if (errorListener != null && scmpMsg.getTypeCode().isError()) {
-      errorListener.accept(scmpMsg);
+    synchronized (stateLock) {
+      if (errorListener != null && scmpMsg.getTypeCode().isError()) {
+        errorListener.accept(scmpMsg);
+      }
     }
   }
 
@@ -258,70 +353,112 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     channel.send(buffer, address);
   }
 
-  public synchronized Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {
-    Consumer<Scmp.Message> old = errorListener;
-    errorListener = listener;
-    return old;
+  public Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {
+    synchronized (stateLock) {
+      Consumer<Scmp.Message> old = errorListener;
+      errorListener = listener;
+      return old;
+    }
   }
 
   protected void checkOpen() throws ClosedChannelException {
-    if (!channel.isOpen()) {
-      throw new ClosedChannelException();
+    synchronized (stateLock) {
+      if (!channel.isOpen()) {
+        throw new ClosedChannelException();
+      }
     }
   }
 
   protected void checkConnected(boolean requiredState) {
-    boolean isConnected = connectionPath != null;
-    if (requiredState != isConnected) {
-      if (isConnected) {
-        throw new AlreadyConnectedException();
-      } else {
-        throw new NotYetConnectedException();
+    synchronized (stateLock) {
+      boolean isConnected = connectionPath != null;
+      if (requiredState != isConnected) {
+        if (isConnected) {
+          throw new AlreadyConnectedException();
+        } else {
+          throw new NotYetConnectedException();
+        }
       }
     }
   }
 
-  public synchronized boolean isConnected() {
-    return connectionPath != null;
-  }
-
-  @SuppressWarnings("unchecked")
-  public synchronized <T> T getOption(SocketOption<T> option) throws IOException {
-    if (option instanceof ScionSocketOptions.SciSocketOption) {
-      if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
-        return (T) (Boolean) cfgReportFailedValidation;
-      } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
-        return (T) (Integer) cfgExpirationSafetyMargin;
-      } else {
-        throw new UnsupportedOperationException();
-      }
+  public boolean isConnected() {
+    synchronized (stateLock) {
+      return connectionPath != null;
     }
-    return channel.getOption(option);
   }
 
-  @SuppressWarnings("unchecked")
-  public synchronized <T> C setOption(SocketOption<T> option, T t) throws IOException {
-    if (option instanceof ScionSocketOptions.SciSocketOption) {
-      if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
-        cfgReportFailedValidation = (Boolean) t;
-      } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
-        cfgExpirationSafetyMargin = (Integer) t;
-      } else {
-        throw new UnsupportedOperationException();
+  @SuppressWarnings({"unchecked", "deprecation"})
+  public <T> T getOption(SocketOption<T> option) throws IOException {
+    synchronized (stateLock) {
+      if (option instanceof ScionSocketOptions.SciSocketOption) {
+        if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
+          return (T) (Boolean) cfgReportFailedValidation;
+        } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
+          return (T) (Integer) cfgExpirationSafetyMargin;
+        } else if (ScionSocketOptions.SN_TRAFFIC_CLASS.equals(option)) {
+          return (T) (Integer) cfgTrafficClass;
+        } else {
+          throw new UnsupportedOperationException();
+        }
       }
-    } else if (StandardSocketOptions.SO_RCVBUF.equals(option)
-        || StandardSocketOptions.SO_SNDBUF.equals(option)) {
-      channel.setOption(option, t);
-      resizeBuffers(
-          channel.getOption(StandardSocketOptions.SO_RCVBUF),
-          channel.getOption(StandardSocketOptions.SO_SNDBUF));
-    } else {
-      channel.setOption(option, t);
+      return channel.getOption(option);
     }
-    return (C) this;
   }
 
-  protected abstract void resizeBuffers(int sizeReceive, int sizeSend);
+  @SuppressWarnings({"unchecked", "deprecation"})
+  public <T> C setOption(SocketOption<T> option, T t) throws IOException {
+    synchronized (stateLock) {
+      if (option instanceof ScionSocketOptions.SciSocketOption) {
+        if (ScionSocketOptions.SN_API_THROW_PARSER_FAILURE.equals(option)) {
+          cfgReportFailedValidation = (Boolean) t;
+        } else if (ScionSocketOptions.SN_PATH_EXPIRY_MARGIN.equals(option)) {
+          cfgExpirationSafetyMargin = (Integer) t;
+        } else if (ScionSocketOptions.SN_TRAFFIC_CLASS.equals(option)) {
+          int trafficClass = (Integer) t;
+          if (trafficClass < 0 || trafficClass > 255) {
+            throw new IllegalArgumentException("trafficClass is not in range 0 -- 255");
+          }
+          cfgTrafficClass = trafficClass;
+        } else {
+          throw new UnsupportedOperationException();
+        }
+      } else {
+        channel.setOption(option, t);
+      }
+      return (C) this;
+    }
+  }
+
+  protected final ByteBuffer bufferSend() {
+    return bufferSend;
+  }
+
+  protected final ByteBuffer bufferReceive() {
+    return bufferReceive;
+  }
+
+  private void resizeBuffers(InetAddress address) throws SocketException {
+    int mtu;
+    mtu = NetworkInterface.getByInetAddress(address).getMTU();
+    readLock().lock();
+    try {
+      if (bufferReceive.capacity() < mtu) {
+        bufferReceive = ByteBuffer.allocateDirect(mtu);
+      }
+    } finally {
+      readLock().unlock();
+    }
+
+    writeLock().lock();
+    try {
+      if (bufferSend.capacity() < mtu) {
+        bufferSend = ByteBuffer.allocateDirect(mtu);
+      }
+    } finally {
+      writeLock().unlock();
+    }
+  }
 
   /**
    * @param path path
@@ -329,14 +466,16 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
    * @return argument path or a new path if the argument path was expired
    * @throws IOException in case of IOException.
    */
-  protected Path buildHeader(
+  protected Path checkPathAndBuildHeader(
       ByteBuffer buffer, Path path, int payloadLength, InternalConstants.HdrTypes hdrType)
       throws IOException {
-    if (path instanceof RequestPath) {
-      path = ensureUpToDate((RequestPath) path);
+    synchronized (stateLock) {
+      if (path instanceof RequestPath) {
+        path = ensureUpToDate((RequestPath) path);
+      }
+      buildHeader(buffer, path, payloadLength, hdrType);
+      return path;
     }
-    buildHeaderNoRefresh(buffer, path, payloadLength, hdrType);
-    return path;
   }
 
   /**
@@ -346,74 +485,106 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
    * @param hdrType Header type e.g. SCMP
    * @throws IOException in case of IOException.
    */
-  protected void buildHeaderNoRefresh(
+  protected void buildHeader(
       ByteBuffer buffer, Path path, int payloadLength, InternalConstants.HdrTypes hdrType)
       throws IOException {
-    buffer.clear();
-    long srcIA;
-    byte[] srcAddress;
-    int srcPort;
-    if (path instanceof ResponsePath) {
-      // We could get source IA, address and port locally, but it seems cleaner
-      // to get these from the inverted header.
-      ResponsePath rPath = (ResponsePath) path;
-      srcIA = rPath.getSourceIsdAs();
-      srcAddress = rPath.getSourceAddress();
-      srcPort = rPath.getSourcePort();
-    } else {
-      // For sending request path we need to have a valid local external address.
-      // For a valid local external address we need to be connected.
-      if (!channel.isConnected()) {
-        channel.connect(path.getFirstHopAddress());
+    synchronized (stateLock) {
+      ensureBound();
+      buffer.clear();
+      long srcIA;
+      byte[] srcAddress;
+      int srcPort;
+      if (path instanceof ResponsePath) {
+        // We could get source IA, address and port locally, but it seems cleaner
+        // to get these from the inverted header.
+        ResponsePath rPath = (ResponsePath) path;
+        srcIA = rPath.getSourceIsdAs();
+        srcAddress = rPath.getSourceAddress();
+        srcPort = rPath.getSourcePort();
+      } else {
+        srcIA = getOrCreateService().getLocalIsdAs();
+        // Get external host address. This must be done *after* refreshing the path!
+        if (localAddress.isAnyLocalAddress()) {
+          // For sending request path we need to have a valid local external address.
+          // If the local address is a wildcard address then we get the external IP
+          // elsewhere (from the service).
+
+          // TODO cache this or add it to path object?
+          srcAddress = getOrCreateService().getExternalIP(path.getFirstHopAddress()).getAddress();
+        } else {
+          srcAddress = localAddress.getAddress();
+        }
+        srcPort = ((InetSocketAddress) channel.getLocalAddress()).getPort();
+        if (srcPort == 0) {
+          // This has apparently been fixed in Java 14: https://bugs.openjdk.org/browse/JDK-8231880
+          throw new IllegalStateException(
+              "Local port is 0. This happens after calling "
+                  + "disconnect(). Please connect() or bind() before send() or write().");
+        }
       }
 
-      srcIA = getOrCreateService().getLocalIsdAs();
-      // Get external host address. This must be done *after* refreshing the path!
-      InetSocketAddress srcSocketAddress = (InetSocketAddress) channel.getLocalAddress();
-      srcAddress = srcSocketAddress.getAddress().getAddress();
-      srcPort = srcSocketAddress.getPort();
-    }
+      long dstIA = path.getDestinationIsdAs();
+      byte[] dstAddress = path.getDestinationAddress();
+      int dstPort = path.getDestinationPort();
 
-    long dstIA = path.getDestinationIsdAs();
-    byte[] dstAddress = path.getDestinationAddress();
-    int dstPort = path.getDestinationPort();
+      byte[] rawPath = path.getRawPath();
+      ScionHeaderParser.write(
+          buffer, payloadLength, rawPath.length, srcIA, srcAddress, dstIA, dstAddress, hdrType);
+      ScionHeaderParser.writePath(buffer, rawPath);
 
-    byte[] rawPath = path.getRawPath();
-    ScionHeaderParser.write(
-        buffer, payloadLength, rawPath.length, srcIA, srcAddress, dstIA, dstAddress, hdrType);
-    ScionHeaderParser.writePath(buffer, rawPath);
-
-    if (hdrType == InternalConstants.HdrTypes.UDP) {
-      ScionHeaderParser.writeUdpOverlayHeader(buffer, payloadLength, srcPort, dstPort);
+      if (hdrType == InternalConstants.HdrTypes.UDP) {
+        ScionHeaderParser.writeUdpOverlayHeader(buffer, payloadLength, srcPort, dstPort);
+      }
     }
   }
 
   protected RequestPath ensureUpToDate(RequestPath path) throws IOException {
-    if (Instant.now().getEpochSecond() + cfgExpirationSafetyMargin <= path.getExpiration()) {
-      return path;
+    synchronized (stateLock) {
+      if (Instant.now().getEpochSecond() + cfgExpirationSafetyMargin <= path.getExpiration()) {
+        return path;
+      }
+      // expired, get new path
+      RequestPath newPath = pathPolicy.filter(getOrCreateService().getPaths(path));
+      if (isConnected()) {
+        updateConnection(newPath, true);
+      }
+      return newPath;
     }
-    return updatePath(path);
   }
 
-  private RequestPath updatePath(RequestPath path) throws IOException {
-    // expired, get new path
-    RequestPath newPath = pathPolicy.filter(getOrCreateService().getPaths(path));
-
-    if (connectionPath != null) { // equal to !isBound at this point
-      if (!newPath.getFirstHopAddress().equals(path.getFirstHopAddress())) {
-        channel.disconnect();
-        channel.connect(newPath.getFirstHopAddress());
-      }
-      connectionPath = newPath;
+  private void updateConnection(RequestPath newPath, boolean mustBeConnected) throws IOException {
+    if (mustBeConnected && !isConnected()) {
+      throw new IllegalStateException();
     }
-    return newPath;
+    // update connected path
+    connectionPath = newPath;
+    // update local address
+    InetAddress oldLocalAddress = localAddress;
+    // TODO we should not change the local address if bind() was called with an explicit address!
+    // API: returning the localAddress should return non-ANY if we have a connection
+    //     I.e. getExternalIP() is fine if we have a connection.
+    //     It is NOT fine if we are bound to an explicit IP/port
+    localAddress = getOrCreateService().getExternalIP(newPath.getFirstHopAddress());
+    if (!Objects.equals(localAddress, oldLocalAddress)) {
+      resizeBuffers(localAddress);
+    }
   }
 
   protected boolean validate(ByteBuffer buffer) throws ScionException {
-    String validationResult = ScionHeaderParser.validate(buffer.asReadOnlyBuffer());
-    if (validationResult != null && cfgReportFailedValidation) {
-      throw new ScionException(validationResult);
+    synchronized (stateLock) {
+      String validationResult = ScionHeaderParser.validate(buffer.asReadOnlyBuffer());
+      if (validationResult != null && cfgReportFailedValidation) {
+        throw new ScionException(validationResult);
+      }
+      return validationResult == null;
     }
-    return validationResult == null;
+  }
+
+  protected ReentrantLock readLock() {
+    return this.readLock;
+  }
+
+  protected ReentrantLock writeLock() {
+    return writeLock;
   }
 }

--- a/src/main/java/org/scion/ScionSocketOptions.java
+++ b/src/main/java/org/scion/ScionSocketOptions.java
@@ -45,6 +45,15 @@ public final class ScionSocketOptions {
   public static final SocketOption<Integer> SN_PATH_EXPIRY_MARGIN =
       new SciSocketOption<>("SN_PATH_EXPIRY_MARGIN", Integer.class);
 
+  /**
+   * Set the traffic class SCION header.
+   *
+   * @deprecated This feature may be removed in a future release
+   */
+  @Deprecated
+  public static final SocketOption<Integer> SN_TRAFFIC_CLASS =
+      new SciSocketOption<>("SN_TRAFFIC_CLASS", Integer.class);
+
   private ScionSocketOptions() {}
 
   static class SciSocketOption<T> implements SocketOption<T> {

--- a/src/main/java/org/scion/ScmpChannel.java
+++ b/src/main/java/org/scion/ScmpChannel.java
@@ -17,7 +17,6 @@ package org.scion;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
-import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectionKey;
@@ -127,65 +126,77 @@ public class ScmpChannel implements AutoCloseable {
   }
 
   private class InternalChannel extends AbstractDatagramChannel<InternalChannel> {
-    private ByteBuffer bufferReceive;
-    private ByteBuffer bufferSend;
     private final Selector selector;
 
     protected InternalChannel(ScionService service, RequestPath path, int port) throws IOException {
       super(service);
-      this.bufferReceive = ByteBuffer.allocateDirect(getOption(StandardSocketOptions.SO_RCVBUF));
-      this.bufferSend = ByteBuffer.allocateDirect(getOption(StandardSocketOptions.SO_SNDBUF));
 
       // selector
       this.selector = Selector.open();
       super.channel().configureBlocking(false);
       super.channel().register(selector, SelectionKey.OP_READ);
 
-      super.setConnectionPath(path);
       // listen on ANY interface: 0.0.0.0 / [::]
       super.bind(new InetSocketAddress("[::]", port));
+      super.connect(path);
     }
 
     synchronized Scmp.TimedMessage sendEchoRequest(Scmp.EchoMessage request) throws IOException {
-      // EchoHeader = 8 + data
-      int len = 8 + request.getData().length;
-      Path path = request.getPath();
-      buildHeaderNoRefresh(bufferSend, request.getPath(), len, InternalConstants.HdrTypes.SCMP);
-      ScmpParser.buildScmpPing(
-          bufferSend, getLocalAddress().getPort(), request.getSequenceNumber(), request.getData());
-      bufferSend.flip();
-      request.setSizeSent(bufferSend.remaining());
-      sendRaw(bufferSend, path.getFirstHopAddress());
+      try {
+        Path path = request.getPath();
+        super.channel().connect(path.getFirstHopAddress());
+        ByteBuffer buffer = bufferSend();
+        // EchoHeader = 8 + data
+        int len = 8 + request.getData().length;
+        buildHeader(buffer, request.getPath(), len, InternalConstants.HdrTypes.SCMP);
+        ScmpParser.buildScmpPing(
+            buffer, getLocalAddress().getPort(), request.getSequenceNumber(), request.getData());
+        buffer.flip();
+        request.setSizeSent(buffer.remaining());
+        sendRaw(buffer, path.getFirstHopAddress());
 
-      receiveRequest(request);
-      request.setSizeReceived(bufferReceive.position());
-      return request;
+        receiveRequest(request);
+        request.setSizeReceived(bufferReceive().position());
+        return request;
+      } finally {
+        if (super.channel().isConnected()) {
+          super.channel().disconnect();
+        }
+      }
     }
 
     synchronized Scmp.TimedMessage sendTracerouteRequest(
         Scmp.TracerouteMessage request, PathHeaderParser.Node node) throws IOException {
-      Path path = request.getPath();
-      // TracerouteHeader = 24
-      int len = 24;
-      buildHeaderNoRefresh(bufferSend, path, len, InternalConstants.HdrTypes.SCMP);
-      int interfaceNumber = request.getSequenceNumber();
-      ScmpParser.buildScmpTraceroute(bufferSend, getLocalAddress().getPort(), interfaceNumber);
-      bufferSend.flip();
+      try {
+        Path path = request.getPath();
+        super.channel().connect(path.getFirstHopAddress());
+        ByteBuffer buffer = bufferSend();
+        // TracerouteHeader = 24
+        int len = 24;
+        buildHeader(buffer, path, len, InternalConstants.HdrTypes.SCMP);
+        int interfaceNumber = request.getSequenceNumber();
+        ScmpParser.buildScmpTraceroute(buffer, getLocalAddress().getPort(), interfaceNumber);
+        buffer.flip();
 
-      // Set flags for border routers to return SCMP packet
-      int posPath = ScionHeaderParser.extractPathHeaderPosition(bufferSend);
-      bufferSend.put(posPath + node.posHopFlags, node.hopFlags);
+        // Set flags for border routers to return SCMP packet
+        int posPath = ScionHeaderParser.extractPathHeaderPosition(buffer);
+        buffer.put(posPath + node.posHopFlags, node.hopFlags);
 
-      sendRaw(bufferSend, path.getFirstHopAddress());
+        sendRaw(buffer, path.getFirstHopAddress());
 
-      receiveRequest(request);
-      return request;
+        receiveRequest(request);
+        return request;
+      } finally {
+        if (super.channel().isConnected()) {
+          super.channel().disconnect();
+        }
+      }
     }
 
     synchronized void receiveRequest(Scmp.TimedMessage request) throws IOException {
-      ResponsePath receivePath = receiveWithTimeout(bufferReceive);
+      ResponsePath receivePath = receiveWithTimeout(bufferReceive());
       if (receivePath != null) {
-        ScmpParser.consume(bufferReceive, request);
+        ScmpParser.consume(bufferReceive(), request);
         request.setPath(receivePath);
         checkListeners(request);
       } else {
@@ -224,16 +235,6 @@ public class ScmpChannel implements AutoCloseable {
             }
           }
         }
-      }
-    }
-
-    @Override
-    protected void resizeBuffers(int sizeReceive, int sizeSend) {
-      if (bufferReceive.capacity() != sizeReceive) {
-        bufferReceive = ByteBuffer.allocateDirect(sizeReceive);
-      }
-      if (bufferSend.capacity() != sizeSend) {
-        bufferSend = ByteBuffer.allocateDirect(sizeSend);
       }
     }
 

--- a/src/test/java/org/scion/api/DatagramChannelApiConcurrencyTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelApiConcurrencyTest.java
@@ -1,0 +1,207 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.net.*;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.scion.*;
+import org.scion.testutil.MockDNS;
+import org.scion.testutil.MockDaemon;
+
+class DatagramChannelApiConcurrencyTest {
+
+  private static final int dummyPort = 44444;
+  private static final InetAddress dummyIPv4;
+  private static final InetSocketAddress dummyAddress;
+
+  static {
+    try {
+      dummyIPv4 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+      dummyAddress = new InetSocketAddress(dummyIPv4, dummyPort);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @BeforeEach
+  public void beforeEach() throws IOException {
+    MockDaemon.createAndStartDefault();
+  }
+
+  @AfterEach
+  public void afterEach() throws IOException {
+    MockDaemon.closeDefault();
+    MockDNS.clear();
+  }
+
+  @AfterAll
+  public static void afterAll() {
+    // Defensive clean up
+    ScionService.closeDefault();
+  }
+
+  /** Test 2x receive() and 1x send(). */
+  @Test
+  void concurrentReceive() throws IOException {
+    concurrentReceive(this::receive, this::receive, this::send, false);
+  }
+
+  /** Test 2x read() and 1x write(). */
+  @Test
+  void concurrentRead() throws IOException {
+    concurrentReceive(this::read, this::read, this::write, true);
+  }
+
+  private interface Reader {
+    void run(DatagramChannel channel, AtomicInteger receiveCount);
+  }
+
+  private interface Writer {
+    void run(DatagramChannel channel, CountDownLatch receiveCount);
+  }
+
+  /** Test 2x receive() and 1x send(). */
+  private void concurrentReceive(Reader c1, Reader c2, Writer w1, boolean connect)
+      throws IOException {
+    AtomicInteger receiveCount = new AtomicInteger();
+    CountDownLatch senderLatch = new CountDownLatch(1);
+    ByteBuffer buffer = ByteBuffer.allocate(100);
+    buffer.put("Hello scion!".getBytes());
+    buffer.flip();
+    try (DatagramChannel server = DatagramChannel.open()) {
+      server.bind(dummyAddress);
+      server.configureBlocking(false);
+
+      try (DatagramChannel client = DatagramChannel.open()) {
+        client.configureBlocking(true);
+        if (connect) {
+          client.connect(dummyAddress);
+        }
+        Thread r1 = new Thread(() -> c1.run(client, receiveCount));
+        Thread r2 = new Thread(() -> c2.run(client, receiveCount));
+        Thread s1 = new Thread(() -> w1.run(client, senderLatch));
+        try {
+          r1.start();
+          r2.start();
+
+          // A little race here is difficult to avoid ....
+          assertEquals(0, receiveCount.get());
+
+          s1.start();
+
+          // Check that sending in parallel works
+          senderLatch.await(1, TimeUnit.SECONDS);
+          assertEquals(0, receiveCount.get());
+
+          // Check that these work
+          assertTrue(client.isBlocking());
+          assertEquals(connect, client.isConnected());
+          if (connect) {
+            assertEquals(dummyAddress, client.getRemoteAddress());
+          } else {
+            assertNull(client.getConnectionPath());
+            assertNull(client.getRemoteAddress());
+          }
+
+          // check that receive is responsive
+          ResponsePath path = server.receive(buffer);
+          server.send(buffer, path);
+          // wait
+          synchronized (receiveCount) {
+            receiveCount.wait(1000);
+          }
+          assertEquals(1, receiveCount.get());
+
+          // send again to trigger 2nd receiver
+          buffer.flip();
+          server.send(buffer, path);
+          // wait
+          synchronized (receiveCount) {
+            receiveCount.wait(1000);
+          }
+          assertEquals(2, receiveCount.get());
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        } finally {
+          r1.interrupt();
+          r2.interrupt();
+          s1.interrupt();
+        }
+      }
+    }
+  }
+
+  private void receive(DatagramChannel channel, AtomicInteger receiveCount) {
+    ByteBuffer buffer = ByteBuffer.allocate(100);
+    try {
+      channel.receive(buffer);
+      buffer.flip();
+      assertEquals(12, buffer.remaining());
+      receiveCount.incrementAndGet();
+      synchronized (receiveCount) {
+        receiveCount.notifyAll();
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void send(DatagramChannel channel, CountDownLatch latch) {
+    ByteBuffer buffer = ByteBuffer.wrap("Hello scion!".getBytes());
+    try {
+      buffer.flip();
+      channel.send(buffer, dummyAddress);
+      latch.countDown();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void read(DatagramChannel channel, AtomicInteger receiveCount) {
+    ByteBuffer buffer = ByteBuffer.allocate(100);
+    try {
+      channel.read(buffer);
+      buffer.flip();
+      assertEquals(12, buffer.remaining());
+      receiveCount.incrementAndGet();
+      synchronized (receiveCount) {
+        receiveCount.notifyAll();
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void write(DatagramChannel channel, CountDownLatch latch) {
+    ByteBuffer buffer = ByteBuffer.wrap("Hello scion!".getBytes());
+    try {
+      buffer.flip();
+      channel.write(buffer);
+      latch.countDown();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/org/scion/api/DatagramChannelMultiSendInetAddrTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelMultiSendInetAddrTest.java
@@ -41,15 +41,13 @@ class DatagramChannelMultiSendInetAddrTest {
   void test() {
     PingPongHelper.Server serverFn = PingPongHelper::defaultServer;
     PingPongHelper.Client clientFn = this::client;
-    PingPongHelper pph = new PingPongHelper(1, 20, 50);
-    // TODO this fails only when running ALL unit tests
+    PingPongHelper pph = new PingPongHelper(1, 20, 50, false);
     pph.runPingPong(serverFn, clientFn);
   }
 
   private void client(DatagramChannel channel, Path serverAddress, int id) throws IOException {
     String message = PingPongHelper.MSG + "-" + id;
     ByteBuffer sendBuf = ByteBuffer.wrap(message.getBytes());
-    channel.disconnect();
     // Test send() with InetAddress
     InetAddress inetServerAddress = InetAddress.getByAddress(serverAddress.getDestinationAddress());
     InetSocketAddress inetServerSocketAddress =

--- a/src/test/java/org/scion/api/DatagramChannelMultiSendPathTest.java
+++ b/src/test/java/org/scion/api/DatagramChannelMultiSendPathTest.java
@@ -39,14 +39,13 @@ class DatagramChannelMultiSendPathTest {
   void test() {
     PingPongHelper.Server serverFn = PingPongHelper::defaultServer;
     PingPongHelper.Client clientFn = this::client;
-    PingPongHelper pph = new PingPongHelper(1, 20, 50);
+    PingPongHelper pph = new PingPongHelper(1, 20, 50, false);
     pph.runPingPong(serverFn, clientFn);
   }
 
   private void client(DatagramChannel channel, Path serverAddress, int id) throws IOException {
     String message = PingPongHelper.MSG + "-" + id;
     ByteBuffer sendBuf = ByteBuffer.wrap(message.getBytes());
-    channel.disconnect();
     channel.send(sendBuf, serverAddress);
 
     // System.out.println("CLIENT: Receiving ... (" + channel.getLocalAddress() + ")");

--- a/src/test/java/org/scion/demo/PingPongChannelClient.java
+++ b/src/test/java/org/scion/demo/PingPongChannelClient.java
@@ -52,7 +52,7 @@ public class PingPongChannelClient {
     println("Received from server at: " + remoteAddress + "  message: " + message);
   }
 
-  public static void main(String[] args) throws IOException, InterruptedException {
+  public static void main(String[] args) throws IOException {
     // Demo setup
     switch (NETWORK) {
       case MOCK_TOPOLOGY_IPV4:

--- a/src/test/java/org/scion/demo/PingPongDemoTest.java
+++ b/src/test/java/org/scion/demo/PingPongDemoTest.java
@@ -16,7 +16,6 @@ package org.scion.demo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ public class PingPongDemoTest {
             () -> {
               try {
                 PingPongChannelServer.main(null);
-              } catch (IOException e) {
+              } catch (Throwable e) {
                 failures.incrementAndGet();
                 throw new RuntimeException(e);
               }
@@ -55,7 +54,7 @@ public class PingPongDemoTest {
             () -> {
               try {
                 PingPongChannelClient.main(null);
-              } catch (IOException | InterruptedException e) {
+              } catch (Throwable e) {
                 failures.incrementAndGet();
                 throw new RuntimeException(e);
               }
@@ -67,6 +66,9 @@ public class PingPongDemoTest {
     // just in case
     server.interrupt();
     client.interrupt();
+    // join again to make sure the interrupt was handled
+    server.join(100);
+    client.join(100);
 
     assertEquals(0, failures.get());
   }

--- a/src/test/java/org/scion/demo/inspector/ScionHeader.java
+++ b/src/test/java/org/scion/demo/inspector/ScionHeader.java
@@ -30,7 +30,7 @@ public class ScionHeader {
   //  4 bit: Version : Currently, only 0 is supported.
   private int version;
   //  8 bit: TrafficClass / QoS
-  private int trafficLClass;
+  private int trafficClass;
   // 20 bit: FlowID
   private int flowId;
   //  8 bit: NextHdr
@@ -82,7 +82,7 @@ public class ScionHeader {
     int i1 = data.getInt();
     int i2 = data.getInt();
     version = readInt(i0, 0, 4);
-    trafficLClass = readInt(i0, 4, 8);
+    trafficClass = readInt(i0, 4, 8);
     flowId = readInt(i0, 12, 20);
     nextHeader = readInt(i1, 0, 8);
     hdrLen = readInt(i1, 8, 8);
@@ -197,7 +197,7 @@ public class ScionHeader {
     sb.append("Common Header: " + "  VER=")
         .append(version)
         .append("  TrafficClass=")
-        .append(trafficLClass)
+        .append(trafficClass)
         .append("  FlowID=")
         .append(flowId)
         // .append("\n")
@@ -318,5 +318,9 @@ public class ScionHeader {
 
   public Constants.HdrTypes nextHeader() {
     return Constants.HdrTypes.parse(nextHeader);
+  }
+
+  public int getTrafficClass() {
+    return trafficClass;
   }
 }

--- a/src/test/java/org/scion/demo/inspector/ScionPacketInspector.java
+++ b/src/test/java/org/scion/demo/inspector/ScionPacketInspector.java
@@ -36,9 +36,13 @@ public class ScionPacketInspector {
     return new ScionPacketInspector();
   }
 
-  public static ScionPacketInspector readPacket(ByteBuffer buffer) throws IOException {
+  public static ScionPacketInspector readPacket(ByteBuffer buffer) {
     ScionPacketInspector spi = new ScionPacketInspector();
-    spi.read(buffer);
+    try {
+      spi.read(buffer);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     return spi;
   }
 

--- a/src/test/java/org/scion/testutil/MockDaemon.java
+++ b/src/test/java/org/scion/testutil/MockDaemon.java
@@ -83,6 +83,8 @@ public class MockDaemon implements AutoCloseable {
       DEFAULT.close();
       DEFAULT = null;
     }
+    System.clearProperty(Constants.PROPERTY_DAEMON_HOST);
+    System.clearProperty(Constants.PROPERTY_DAEMON_PORT);
   }
 
   private MockDaemon(InetSocketAddress address) {

--- a/src/test/java/org/scion/testutil/PingPongHelper.java
+++ b/src/test/java/org/scion/testutil/PingPongHelper.java
@@ -19,45 +19,24 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.Charset;
-import java.util.Iterator;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.scion.DatagramChannel;
 import org.scion.Path;
 import org.scion.RequestPath;
-import org.scion.Scion;
 
-public class PingPongHelper {
-
-  public static final String MSG = "Hello scion!";
-  private static final int TIMEOUT = 10; // seconds
-  private final CountDownLatch shutDownBarrier;
-
-  private final int nClients;
-  private final int nServers;
-  private final int nRounds;
-
-  private final AtomicInteger nRoundsClient = new AtomicInteger();
-  private final AtomicInteger nRoundsServer = new AtomicInteger();
-  private final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+public class PingPongHelper extends PingPongHelperBase {
 
   public PingPongHelper(int nServers, int nClients, int nRounds) {
-    this.nClients = nClients;
-    this.nServers = nServers;
-    this.nRounds = nRounds;
-    shutDownBarrier = new CountDownLatch(nClients + nServers);
-    MockNetwork.getAndResetForwardCount();
+    this(nServers, nClients, nRounds, true);
   }
 
-  private abstract class AbstractEndpoint implements Runnable {
-    protected final int id;
+  public PingPongHelper(int nServers, int nClients, int nRounds, boolean connect) {
+    super(nServers, nClients, nRounds, connect);
+  }
 
-    AbstractEndpoint(int id) {
-      this.id = id;
+  private abstract class AbstractChannelEndpoint extends AbstractEndpoint {
+    AbstractChannelEndpoint(int id) {
+      super(id);
     }
 
     abstract void runImpl(DatagramChannel channel) throws IOException;
@@ -79,33 +58,36 @@ public class PingPongHelper {
     }
   }
 
-  private class ClientEndpoint extends AbstractEndpoint {
+  private class ClientEndpoint extends AbstractChannelEndpoint {
     private final Client client;
-    private final RequestPath remoteAddress;
+    private final RequestPath path;
     private final int nRounds;
+    private final boolean connect;
 
-    ClientEndpoint(Client client, int id, RequestPath remoteAddress, int nRounds) {
+    ClientEndpoint(Client client, int id, RequestPath path, int nRounds, boolean connect) {
       super(id);
       this.client = client;
-      this.remoteAddress = remoteAddress;
+      this.path = path;
       this.nRounds = nRounds;
+      this.connect = connect;
     }
 
     @Override
     public final void runImpl(DatagramChannel channel) throws IOException {
-      InetAddress inetAddress = InetAddress.getByAddress(remoteAddress.getDestinationAddress());
-      InetSocketAddress iSAddress =
-          new InetSocketAddress(inetAddress, remoteAddress.getDestinationPort());
-      channel.connect(iSAddress);
+      if (connect) {
+        InetAddress inetAddress = InetAddress.getByAddress(path.getDestinationAddress());
+        InetSocketAddress iSAddress = new InetSocketAddress(inetAddress, path.getDestinationPort());
+        channel.connect(iSAddress);
+      }
       for (int i = 0; i < nRounds; i++) {
-        client.run(channel, remoteAddress, id);
+        client.run(channel, path, id);
         nRoundsClient.incrementAndGet();
       }
       channel.disconnect();
     }
   }
 
-  private class ServerEndpoint extends AbstractEndpoint {
+  private class ServerEndpoint extends AbstractChannelEndpoint {
     private final Server server;
     private final InetSocketAddress localAddress;
     private final int nRounds;
@@ -140,66 +122,11 @@ public class PingPongHelper {
   }
 
   public void runPingPong(Server serverFn, Client clientFn, boolean reset) {
-    try {
-      MockNetwork.startTiny();
-
-      InetSocketAddress serverAddress = MockNetwork.getTinyServerAddress();
-      RequestPath scionAddress = Scion.defaultService().getPaths(serverAddress).get(0);
-      Thread[] servers = new Thread[nServers];
-      for (int i = 0; i < servers.length; i++) {
-        servers[i] = new Thread(new ServerEndpoint(serverFn, i, serverAddress, nRounds * nClients));
-        servers[i].setName("Server-thread-" + i);
-        servers[i].start();
-      }
-
-      Thread[] clients = new Thread[nClients];
-      for (int i = 0; i < clients.length; i++) {
-        clients[i] = new Thread(new ClientEndpoint(clientFn, i, scionAddress, nRounds));
-        clients[i].setName("Client-thread-" + i);
-        clients[i].start();
-      }
-
-      // This enables shutdown in case of an error.
-      // Wait for all threads to finish.
-      if (!shutDownBarrier.await(TIMEOUT, TimeUnit.SECONDS)) {
-        for (Thread client : clients) {
-          client.interrupt();
-        }
-        for (Thread server : servers) {
-          server.interrupt();
-        }
-        if (!shutDownBarrier.await(1, TimeUnit.SECONDS)) {
-          checkExceptions();
-          fail();
-        }
-      }
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    } catch (IOException e) {
-      exceptions.add(e);
-      throw new RuntimeException(e);
-    } finally {
-      MockNetwork.stopTiny();
-      checkExceptions();
-    }
-
-    if (reset) {
-      assertEquals(nRounds * nClients * 2, MockNetwork.getAndResetForwardCount());
-    }
-    assertEquals(nRounds * nClients, nRoundsClient.get());
-    assertEquals(nRounds * nClients, nRoundsServer.get());
-  }
-
-  private void checkExceptions() {
-    for (Iterator<Throwable> it = exceptions.iterator(); it.hasNext(); ) {
-      Throwable t = it.next();
-      if (t instanceof ClosedByInterruptException) {
-        it.remove();
-      }
-      t.printStackTrace();
-    }
-    assertEquals(0, exceptions.size());
-    exceptions.clear();
+    runPingPong(
+        (id, address, nRounds) -> new Thread(new ServerEndpoint(serverFn, id, address, nRounds)),
+        (id, path, nRounds) ->
+            new Thread(new ClientEndpoint(clientFn, id, path, nRounds, connectClients)),
+        reset);
   }
 
   public static void defaultClient(DatagramChannel channel, Path serverAddress, int id)
@@ -222,6 +149,7 @@ public class PingPongHelper {
 
   public static void defaultServer(DatagramChannel channel) throws IOException {
     ByteBuffer request = ByteBuffer.allocate(512);
+    // System.out.println("SERVER: Receiving ... (" + channel.getLocalAddress() + ")");
     Path address = channel.receive(request);
 
     request.flip();
@@ -231,5 +159,6 @@ public class PingPongHelper {
 
     request.flip();
     channel.send(request, address);
+    // System.out.println("SERVER: Sent: " + address);
   }
 }

--- a/src/test/java/org/scion/testutil/PingPongHelperBase.java
+++ b/src/test/java/org/scion/testutil/PingPongHelperBase.java
@@ -1,0 +1,134 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.testutil;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.net.*;
+import java.nio.channels.ClosedByInterruptException;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.scion.RequestPath;
+import org.scion.Scion;
+
+public class PingPongHelperBase {
+
+  public static final String MSG = "Hello scion!";
+  private static final int TIMEOUT = 10; // seconds
+  protected final CountDownLatch shutDownBarrier;
+
+  private final int nClients;
+  protected final int nServers;
+  private final int nRounds;
+  protected final boolean connectClients;
+
+  protected final AtomicInteger nRoundsClient = new AtomicInteger();
+  protected final AtomicInteger nRoundsServer = new AtomicInteger();
+  protected final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+
+  protected PingPongHelperBase(int nServers, int nClients, int nRounds, boolean connect) {
+    this.nClients = nClients;
+    this.nServers = nServers;
+    this.nRounds = nRounds;
+    this.connectClients = connect;
+    shutDownBarrier = new CountDownLatch(nClients + nServers);
+    MockNetwork.getAndResetForwardCount();
+  }
+
+  protected abstract static class AbstractEndpoint implements Runnable {
+    protected final int id;
+
+    AbstractEndpoint(int id) {
+      this.id = id;
+    }
+  }
+
+  public interface ClientFactory {
+    Thread create(int id, RequestPath requestPath, int nRounds);
+  }
+
+  public interface ServerFactory {
+    Thread create(int id, InetSocketAddress serverAddress, int nRounds);
+  }
+
+  public void runPingPong(ServerFactory serverFactory, ClientFactory clientFactory, boolean reset) {
+    try {
+      MockNetwork.startTiny();
+
+      InetSocketAddress serverAddress = MockNetwork.getTinyServerAddress();
+      RequestPath scionAddress = Scion.defaultService().getPaths(serverAddress).get(0);
+      Thread[] servers = new Thread[nServers];
+      for (int i = 0; i < servers.length; i++) {
+        servers[i] = serverFactory.create(i, serverAddress, nRounds * nClients);
+        servers[i].setName("Server-thread-" + i);
+        servers[i].start();
+      }
+
+      Thread[] clients = new Thread[nClients];
+      for (int i = 0; i < clients.length; i++) {
+        clients[i] = clientFactory.create(i, scionAddress, nRounds);
+        clients[i].setName("Client-thread-" + i);
+        clients[i].start();
+      }
+
+      // This enables shutdown in case of an error.
+      // Wait for all threads to finish.
+      if (!shutDownBarrier.await(TIMEOUT, TimeUnit.SECONDS)) {
+        for (Thread client : clients) {
+          client.interrupt();
+        }
+        for (Thread server : servers) {
+          server.interrupt();
+        }
+        if (!shutDownBarrier.await(1, TimeUnit.SECONDS)) {
+          checkExceptions();
+          fail();
+        }
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      exceptions.add(e);
+      throw new RuntimeException(e);
+    } finally {
+      MockNetwork.stopTiny();
+      checkExceptions();
+    }
+
+    if (reset) {
+      assertEquals(nRounds * nClients * 2, MockNetwork.getAndResetForwardCount());
+    }
+    assertEquals(nRounds * nClients, nRoundsClient.get());
+    // For now, we assume that every request is handles by every server thread.
+    // we may have to make this configurable for future tests that work differently.
+    assertEquals(nServers * nRounds * nClients, nRoundsServer.get());
+  }
+
+  private void checkExceptions() {
+    for (Iterator<Throwable> it = exceptions.iterator(); it.hasNext(); ) {
+      Throwable t = it.next();
+      if (t instanceof ClosedByInterruptException) {
+        it.remove();
+      }
+      t.printStackTrace();
+    }
+    assertEquals(0, exceptions.size());
+    exceptions.clear();
+  }
+}

--- a/src/test/java/org/scion/testutil/Util.java
+++ b/src/test/java/org/scion/testutil/Util.java
@@ -1,0 +1,30 @@
+// Copyright 2024 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.testutil;
+
+public class Util {
+  public static int getJavaMajorVersion() {
+    String v = System.getProperty("java.version");
+    if (v.startsWith("1.")) {
+      v = v.substring(2, 3);
+    } else {
+      int indexOfDot = v.indexOf(".");
+      if (indexOfDot >= 0) {
+        v = v.substring(0, indexOfDot);
+      }
+    }
+    return Integer.parseInt(v);
+  }
+}


### PR DESCRIPTION
`DatagramChannel` improvements:

- Better concurrency support
- Fixed handling of `connect()`, `disconnect()` and `bind()`
- Fixed buffer resizing with MTU
- Removed duplicate code
- General clean up

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-java-client/35)
<!-- Reviewable:end -->
