### PR TITLE
Support dispatcher in local AS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for `/etc/scion/hosts` and for OS search domains (e.g. `/etc/resolv.conf`). 
   [#40](https://github.com/netsec-ethz/scion-java-client/pull/40)
 - CI builds for Windows and MacOS. [#41](https://github.com/netsec-ethz/scion-java-client/pull/41)
+- Added support communicating with a dispatcher-endhost in the local AS, see 
+  `DatagramChannel.configureRemoteDispatcher`. 
+  [#46](https://github.com/netsec-ethz/scion-java-client/pull/46)
 
 ### Changed
 - BREAKING CHANGE: Changed maven artifactId to "client"
@@ -38,7 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#35](https://github.com/netsec-ethz/scion-java-client/pull/35)
 - **BREAKING CHANGE**: Renamed project to `jpan`. 
   [#43](https://github.com/netsec-ethz/scion-java-client/pull/43),
-  [#46](https://github.com/netsec-ethz/scion-java-client/pull/46)
+  [#45](https://github.com/netsec-ethz/scion-java-client/pull/45)
 - **BREAKING CHANGE**: `Path` now returns `InetAddress` instead of `byte[]`
   [#44](https://github.com/netsec-ethz/scion-java-client/pull/44)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ JPAN can be used in one of the following ways:
 - You can use JPAN stand-alone (without local SCION installation),
   however it must listen on port 30041 for incoming SCION packets because
   SCION routers currently will forward data only to that port. 
-- If you need a local SCION installation (Go implementation),
+- If you are contacting an endhost within your own AS, and the endhost uses a dispatcher, then you 
+  must set the flag `DatagramChannel.configureRemoteDispatcher(true)`. This ensure that the outgoing
+  packet is sent to port 30041 on the remote machine. The flag has no effect on traffic sent to a 
+  remote AS. 
+- If you need a local SCION installation on your machine (Go implementation),
   consider using the dispatch-off branch/PR.
 - When you need to run a local system with dispatcher, you can try to use port forwarding
   to forward incoming data to your Java application port. The application port must not be 30041.

--- a/src/main/java/org/scion/jpan/DatagramChannel.java
+++ b/src/main/java/org/scion/jpan/DatagramChannel.java
@@ -119,7 +119,7 @@ public class DatagramChannel extends AbstractDatagramChannel<DatagramChannel>
         throw new IOException("Packet is larger than max send buffer size.");
       }
       buffer.flip();
-      sendRaw(buffer, actualPath.getFirstHopAddress());
+      sendRaw(buffer, actualPath.getFirstHopAddress(), actualPath);
       return actualPath;
     } finally {
       writeLock().unlock();
@@ -173,7 +173,7 @@ public class DatagramChannel extends AbstractDatagramChannel<DatagramChannel>
       buffer.put(src);
       buffer.flip();
 
-      int sent = channel().send(buffer, getConnectionPath().getFirstHopAddress());
+      int sent = sendRaw(buffer, getConnectionPath().getFirstHopAddress(), getConnectionPath());
       if (sent < buffer.limit() || buffer.remaining() > 0) {
         throw new ScionException("Failed to send all data.");
       }


### PR DESCRIPTION
Add support communicating with a dispatcher-endhost in the local AS, see `DatagramChannel.configureRemoteDispatcher`. 
This method ensures that local packets are sent to port 30041 on the remote host.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-java-client/46)
<!-- Reviewable:end -->
