### PR TITLE
Improved /etc/scion/hosts parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support communicating with a dispatcher-endhost in the local AS, see 
   `DatagramChannel.configureRemoteDispatcher`. 
   [#46](https://github.com/netsec-ethz/scion-java-client/pull/46)
+- Support for comments, multiple spaces and tabs in `/etc/scion/hosts`. 
+  [#47](https://github.com/netsec-ethz/scion-java-client/pull/47)
 
 ### Changed
 - BREAKING CHANGE: Changed maven artifactId to "client"

--- a/src/main/java/org/scion/jpan/internal/HostsFileParser.java
+++ b/src/main/java/org/scion/jpan/internal/HostsFileParser.java
@@ -20,7 +20,6 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -99,7 +98,7 @@ public class HostsFileParser {
       if (s.isEmpty() || s.startsWith("#")) {
         return;
       }
-      String[] lineParts = s.split(" ");
+      String[] lineParts = s.split("\\s+");
       check(lineParts.length >= 2, "Expected ` `");
       String[] addrParts = lineParts[0].split(",");
       check(addrParts.length == 2, "Expected `,`");
@@ -115,8 +114,12 @@ public class HostsFileParser {
       // TODO
       // 4) Singleton ?!?!?!?!!!
 
-      String[] hostNames = Arrays.copyOfRange(lineParts, 1, lineParts.length);
-      for (String hostName : hostNames) {
+      for (int i = 1; i < lineParts.length; i++) {
+        String hostName = lineParts[i];
+        if (hostName.startsWith("#")) {
+          // ignore comments
+          break;
+        }
         entries.put(hostName, new HostEntry(isdIa, inetAddr, hostName));
       }
       // The following may differ, e.g. for IPv6

--- a/src/test/resources/etc-scion-hosts
+++ b/src/test/resources/etc-scion-hosts
@@ -1,11 +1,16 @@
-# /etc/scion/hosts test file
+# /etc/scion/hosts test file with bad formatting
+
 1-ff00:0:111,[42.0.0.11] test-server
-1-ff00:0:112,[42.0.0.12] test-server-1 test-server-2
-1-ff00:0:113,[::42] test-server-ipv6
+#1-ff00:0:111,[42.0.0.111] test-server
+  1-ff00:0:112,[42.0.0.12]  test-server-1   test-server-2  # comment with other test-server
+	1-ff00:0:112,[42.0.0.13]	test-server-3	test-server-4	# tabs instead of spaces
+ 1-ff00:0:113,[::42] test-server-ipv6
 
 # And some wrong lines
 1-ff00:0:114;[42.0.0.10] test-server
 1-ff00:0:114,[42.0.0.10]
+#1-ff00:0:114,
+#1-ff00:0:114
 1-ff00:0:114,42.0.0.10] test-server
 1-ff00:0:114,[42.0.0.10 test-server
 ff00:0:114,[42.0.0.10] test-server


### PR DESCRIPTION
Support for EOL comments, multiple spaces and tabs in `/etc/scion/hosts`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-java-client/47)
<!-- Reviewable:end -->
